### PR TITLE
feat/인증 관련 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@types/node": "^22.10.5",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1461,6 +1462,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -4254,6 +4265,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/node": "^22.10.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,65 @@
+// src/components/common/Button.tsx
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'outline';
+  fullWidth?: boolean;
+  children: React.ReactNode;
+}
+
+export const Button = ({ 
+  variant = 'primary', 
+  fullWidth = false, 
+  children, 
+  className = '', 
+  ...props 
+}: ButtonProps) => {
+  const baseStyles = 'px-4 py-2 rounded-lg font-medium transition-colors duration-200 disabled:opacity-50';
+  const variantStyles = {
+    primary: 'bg-primary text-white hover:bg-primary-dark',
+    secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
+    outline: 'border-2 border-primary text-primary hover:bg-primary-light'
+  };
+  
+  return (
+    <button 
+      className={`${baseStyles} ${variantStyles[variant]} ${fullWidth ? 'w-full' : ''} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+// src/components/common/Input.tsx
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  rightElement?: React.ReactNode;
+}
+
+export const Input = ({ label, error, rightElement, className = '', ...props }: InputProps) => {
+  return (
+    <div className="space-y-1">
+      {label && (
+        <label className="block text-sm font-medium text-gray-700">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          className={`w-full px-3 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${rightElement ? 'pr-24' : ''} ${className}`}
+          {...props}
+        />
+        {rightElement && (
+          <div className="absolute inset-y-0 right-0 flex items-center pr-3">
+            {rightElement}
+          </div>
+        )}
+      </div>
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,34 @@
+// src/components/common/Input.tsx
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  rightElement?: React.ReactNode;
+}
+
+export const Input = ({ label, error, rightElement, className = '', ...props }: InputProps) => {
+  return (
+    <div className="space-y-1">
+      {label && (
+        <label className="block text-sm font-medium text-gray-700">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          className={`w-full px-3 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${rightElement ? 'pr-24' : ''} ${className}`}
+          {...props}
+        />
+        {rightElement && (
+          <div className="absolute inset-y-0 right-0 flex items-center pr-3">
+            {rightElement}
+          </div>
+        )}
+      </div>
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/layout/AuthHeader.tsx
+++ b/src/components/layout/AuthHeader.tsx
@@ -1,0 +1,23 @@
+// src/components/layout/AuthHeader.tsx
+import { Link } from 'react-router-dom';
+
+export default function AuthHeader() {
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <Link to="/" className="flex items-center">
+            <img src="/assets/images/logo-icon.png" alt="RefHub" className="h-8 w-8 mr-2" />
+            <span className="text-xl font-bold text-primary">RefHub</span>
+          </Link>
+          <Link 
+            to="/auth/login"
+            className="text-gray-600 hover:text-primary"
+          >
+            로그인
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,10 +1,29 @@
-import { Outlet } from 'react-router-dom';
+// src/components/layout/Layout.tsx
+import { Outlet, useLocation, Navigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/store/auth';
+import AuthHeader from './AuthHeader';
+import MainHeader from './MainHeader';
 
 export default function Layout() {
+  const location = useLocation();
+  const user = useRecoilValue(userState);
+  const isAuthPage = location.pathname.startsWith('/auth/');
+
+  // 인증이 필요한 페이지에서 비로그인 상태일 경우 로그인 페이지로 리다이렉트
+  if (!isAuthPage && !user) {
+    return <Navigate to="/auth/login" replace />;
+  }
+
+  // 로그인 상태에서 인증 페이지 접근 시 메인 페이지로 리다이렉트
+  if (isAuthPage && user) {
+    return <Navigate to="/" replace />;
+  }
+
   return (
-    <div>
-      <header>Header</header>
-      <main>
+    <div className="min-h-screen flex flex-col">
+      {isAuthPage ? <AuthHeader /> : <MainHeader />}
+      <main className="flex-1">
         <Outlet />
       </main>
     </div>

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -1,0 +1,58 @@
+// src/components/layout/MainHeader.tsx
+import { Link, useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { userState } from '@/store/auth';
+
+export default function MainHeader() {
+  const navigate = useNavigate();
+  const [, setUser] = useRecoilState(userState);
+
+  const handleLogout = () => {
+    setUser(null);
+    navigate('/auth/login');
+  };
+
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          <Link to="/" className="flex items-center">
+            <img src="/assets/images/logo-icon.png" alt="RefHub" className="h-8 w-8 mr-2" />
+            <span className="text-xl font-bold text-primary">RefHub</span>
+          </Link>
+
+          {/* 중앙 네비게이션 */}
+          <nav className="flex items-center space-x-8">
+            <Link 
+              to="/collections" 
+              className="text-gray-600 hover:text-primary text-base font-medium"
+            >
+              나의 컬렉션
+            </Link>
+            <Link 
+              to="/references" 
+              className="text-gray-600 hover:text-primary text-base font-medium"
+            >
+              전체 레퍼런스
+            </Link>
+          </nav>
+
+          <div className="flex items-center space-x-4">
+            <Link
+              to="/references/new"
+              className="px-4 py-2 rounded-lg bg-primary text-white hover:bg-primary-dark"
+            >
+              레퍼런스 추가
+            </Link>
+            <button
+              onClick={handleLogout}
+              className="text-gray-600 hover:text-gray-900"
+            >
+              로그아웃
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,3 +1,87 @@
+// src/pages/auth/LoginPage.tsx
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { Input } from '@/components/common/Input';
+import { Button } from '@/components/common/Button';
+import { userState, DUMMY_USER } from '@/store/auth';
+import type { LoginForm } from '@/types/auth';
+
 export default function LoginPage() {
-  return <div>Login Page</div>;
+  const navigate = useNavigate();
+  const setUser = useSetRecoilState(userState);
+  const { register, handleSubmit, formState: { errors } } = useForm<LoginForm>();
+
+  const onSubmit = async (data: LoginForm) => {
+    // 더미 로그인 처리
+    console.log('Login attempt:', data);
+    setUser(DUMMY_USER);
+    navigate('/');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
+            로그인
+          </h2>
+        </div>
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit(onSubmit)}>
+          <div className="space-y-4">
+            <Input
+              label="이메일"
+              type="email"
+              {...register('email', {
+                required: '이메일을 입력해주세요',
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: '올바른 이메일 형식이 아닙니다'
+                }
+              })}
+              error={errors.email?.message}
+            />
+            <Input
+              label="비밀번호"
+              type="password"
+              {...register('password', {
+                required: '비밀번호를 입력해주세요',
+                minLength: {
+                  value: 8,
+                  message: '비밀번호는 8자 이상이어야 합니다'
+                }
+              })}
+              error={errors.password?.message}
+            />
+          </div>
+
+          <div className="flex items-center justify-end">
+            <Link
+              to="/auth/reset-password"
+              className="text-sm font-medium text-primary hover:text-primary-dark"
+            >
+              비밀번호를 잊으셨나요?
+            </Link>
+          </div>
+
+          <div>
+            <Button type="submit" fullWidth>
+              로그인
+            </Button>
+          </div>
+
+          <div className="text-center">
+            <span className="text-sm text-gray-600">계정이 없으신가요? </span>
+            <Link
+              to="/auth/signup"
+              className="text-sm font-medium text-primary hover:text-primary-dark"
+            >
+              회원가입
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/auth/PasswordResetPage.tsx
+++ b/src/pages/auth/PasswordResetPage.tsx
@@ -1,24 +1,24 @@
-// src/pages/auth/SignupPage.tsx
+// src/pages/auth/PasswordResetPage.tsx
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { Input } from "@/components/common/Input";
 import { Button } from "@/components/common/Button";
-import type { SignupForm } from "@/types/auth";
+import type { PasswordResetForm } from "@/types/auth";
 
-type SignupStep = "INFO" | "VERIFY" | "PASSWORD";
+type ResetStep = "EMAIL" | "VERIFY" | "NEW_PASSWORD";
 
-export default function SignupPage() {
-  const [currentStep, setCurrentStep] = useState<SignupStep>("INFO");
+export default function PasswordResetPage() {
+  const [currentStep, setCurrentStep] = useState<ResetStep>("EMAIL");
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors },
-  } = useForm<SignupForm>();
+  } = useForm<PasswordResetForm>();
   const [isVerificationSent, setIsVerificationSent] = useState(false);
 
-  const onSubmit = async (data: SignupForm) => {
+  const onSubmit = async (data: PasswordResetForm) => {
     // TODO: API 연동 후 구현
     console.log(data);
   };
@@ -26,7 +26,8 @@ export default function SignupPage() {
   const handleSendVerification = async () => {
     // TODO: API 연동 후 구현
     setIsVerificationSent(true);
-    
+    setCurrentStep("VERIFY");
+
     // 1분 후에 재발송 가능하도록 설정
     setTimeout(() => {
       setIsVerificationSent(false);
@@ -35,7 +36,7 @@ export default function SignupPage() {
 
   const handleVerifyCode = async () => {
     // TODO: API 연동 후 구현
-    setCurrentStep("PASSWORD");
+    setCurrentStep("NEW_PASSWORD");
   };
 
   return (
@@ -43,20 +44,13 @@ export default function SignupPage() {
       <div className="max-w-md w-full space-y-8">
         <div>
           <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
-            회원가입
+            비밀번호 변경
           </h2>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit(onSubmit)}>
-          {currentStep === "INFO" && (
+          {currentStep === "EMAIL" && (
             <div className="space-y-4">
-              <Input
-                label="이름"
-                {...register("name", {
-                  required: "이름을 입력해주세요",
-                })}
-                error={errors.name?.message}
-              />
               <Input
                 label="이메일"
                 type="email"
@@ -104,46 +98,43 @@ export default function SignupPage() {
             </div>
           )}
 
-          {currentStep === "PASSWORD" && (
+          {currentStep === "NEW_PASSWORD" && (
             <div className="space-y-4">
               <Input
-                label="비밀번호"
+                label="새 비밀번호"
                 type="password"
-                {...register("password", {
-                  required: "비밀번호를 입력해주세요",
+                {...register("newPassword", {
+                  required: "새 비밀번호를 입력해주세요",
                   minLength: {
                     value: 8,
                     message: "비밀번호는 8자 이상이어야 합니다",
                   },
                 })}
-                error={errors.password?.message}
+                error={errors.newPassword?.message}
               />
               <Input
-                label="비밀번호 확인"
+                label="새 비밀번호 확인"
                 type="password"
-                {...register("passwordConfirm", {
+                {...register("newPasswordConfirm", {
                   required: "비밀번호 확인을 입력해주세요",
                   validate: (value) =>
-                    value === watch("password") ||
+                    value === watch("newPassword") ||
                     "비밀번호가 일치하지 않습니다",
                 })}
-                error={errors.passwordConfirm?.message}
+                error={errors.newPasswordConfirm?.message}
               />
               <Button type="submit" fullWidth>
-                가입하기
+                비밀번호 변경
               </Button>
             </div>
           )}
 
           <div className="text-center">
-            <span className="text-sm text-gray-600">
-              이미 계정이 있으신가요?{" "}
-            </span>
             <Link
               to="/auth/login"
               className="text-sm font-medium text-blue-600 hover:text-blue-500"
             >
-              로그인
+              로그인으로 돌아가기
             </Link>
           </div>
         </form>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,11 @@
 // src/router.tsx
 import { createBrowserRouter } from 'react-router-dom';
-import Layout from './components/layout/Layout';
-import HomePage from './pages/home/HomePage';
-import LoginPage from './pages/auth/LoginPage';
-import SignupPage from './pages/auth/SignupPage';
-import CollectionPage from './pages/collection/CollectionPage';
-import { Navigate } from 'react-router-dom';
+import Layout from '@/components/layout/Layout';
+import LoginPage from '@/pages/auth/LoginPage';
+import SignupPage from '@/pages/auth/SignupPage';
+import PasswordResetPage from '@/pages/auth/PasswordResetPage';
+import HomePage from '@/pages/home/HomePage';
+import CollectionPage from '@/pages/collection/CollectionPage';
 
 export const router = createBrowserRouter([
   {
@@ -17,21 +17,21 @@ export const router = createBrowserRouter([
         element: <HomePage />,
       },
       {
-        path: '/collection/:id',
+        path: '/collections',
         element: <CollectionPage />,
       },
+      {
+        path: '/auth/login',
+        element: <LoginPage />,
+      },
+      {
+        path: '/auth/signup',
+        element: <SignupPage />,
+      },
+      {
+        path: '/auth/reset-password',
+        element: <PasswordResetPage />,
+      },
     ],
-  },
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    path: '/signup',
-    element: <SignupPage />,
-  },
-  {
-    path: '*',
-    element: <Navigate to="/" replace />,
   },
 ]);

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,20 @@
+// src/store/auth.ts
+import { atom } from 'recoil';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export const userState = atom<User | null>({
+  key: 'userState',
+  default: null,
+});
+
+// 더미 사용자 데이터
+export const DUMMY_USER = {
+  id: '1',
+  name: '홍길동',
+  email: 'test@refhub.com',
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,35 @@
+// src/types/auth.ts
+
+export interface LoginForm {
+  email: string;
+  password: string;
+}
+
+export interface SignupForm {
+  name: string;
+  email: string;
+  verificationCode: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+export interface PasswordResetForm {
+  email: string;
+  verificationCode: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// API 응답 타입
+export interface AuthResponse {
+  accessToken: string;
+  user: User;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+// tailwind.config.js
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -7,10 +8,11 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: "#1A6DFF",
-        secondary: "#6691FF",
-        black: "#000000",
-        white: "#FFFFFF",
+        primary: {
+          DEFAULT: '#1ABC9C',
+          light: '#E8F8F5',
+          dark: '#16A085',
+        },
         gray: {
           100: "#F5F5F5",
           200: "#EEEEEE",
@@ -21,7 +23,7 @@ export default {
           700: "#616161",
           800: "#424242",
           900: "#212121",
-        },
+        }
       },
       fontFamily: {
         sans: ['Pretendard', 'sans-serif'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+// vite.config.ts
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__dirname, 'src') }
+    ]
+  }
 })


### PR DESCRIPTION
## 인증 관련 기능 구현

### 주요 변경사항
- 인증 관련 페이지 구현
  - 로그인 페이지
  - 회원가입 페이지
  - 비밀번호 재설정 페이지
- 공통 컴포넌트 구현
  - Button 컴포넌트
  - Input 컴포넌트
- 인증 상태 관리 구현
  - Recoil을 사용한 상태 관리
  - 더미 데이터를 활용한 로그인/로그아웃 기능
- 헤더 컴포넌트 분리
  - AuthHeader: 비로그인 상태의 헤더
  - MainHeader: 로그인 상태의 헤더

### 테스트 방법
1. `/auth/login` 페이지 접속
2. 테스트 계정으로 로그인
   - 이메일: test@refhub.com
   - 비밀번호: password123 (8자 이상)
3. 로그인 후 메인 페이지로 이동 확인
4. 로그아웃 기능 동작 확인

### 리뷰 요청사항
- [ ] 인증 페이지들의 UI가 디자인과 일치하는지 확인
- [ ] 로그인/로그아웃 플로우가 자연스러운지 확인
- [ ] 상태 관리 로직이 적절한지 검토