### PR TITLE
feat: 인증 API 연동 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.64.0",
         "axios": "^1.7.9",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.471.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3022,6 +3023,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.1",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "jwt-decode": "^4.0.0"
+    
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/layout/AuthNavigationHandler.tsx
+++ b/src/components/layout/AuthNavigationHandler.tsx
@@ -1,0 +1,18 @@
+// src/components/layout/AuthNavigationHandler.tsx
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/store/auth';
+
+export function AuthNavigationHandler() {
+  const user = useRecoilValue(userState);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/auth/login');
+    }
+  }, [user, navigate]);
+
+  return null;
+}

--- a/src/components/layout/AuthProvider.tsx
+++ b/src/components/layout/AuthProvider.tsx
@@ -2,26 +2,83 @@
 import { useEffect } from "react";
 import { useSetRecoilState } from "recoil";
 import { userState, authUtils } from "@/store/auth";
+import { authService } from "@/services/auth"; // 추가
+import axios from "axios";
+import { jwtDecode } from "jwt-decode";
+import type { TokenPayload } from "@/types/auth";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const setUser = useSetRecoilState(userState);
 
   useEffect(() => {
-    const initializeAuth = () => {
-      if (authUtils.getRememberMe()) {
-        const storedUser = authUtils.getStoredUser();
-        const token = authUtils.getToken();
-        
-        if (storedUser && token) {
-          setUser(storedUser);
-        } else {
-          // 토큰이나 유저 정보 중 하나라도 없으면 초기화
-          authUtils.clearAll();
+    // 토큰 만료 시간을 체크하는 함수
+    const checkTokenExpiration = (token: string) => {
+      try {
+        const decoded = jwtDecode<TokenPayload>(token);
+        return decoded.exp * 1000 - Date.now() <= 10 * 60 * 1000;
+      } catch {
+        return true;
+      }
+    };
+
+    // API 요청 인터셉터 설정
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response?.status === 401 && !originalRequest._retry) {
+          originalRequest._retry = true;
+
+          try {
+            const refreshToken = authUtils.getRefreshToken();
+            if (!refreshToken) {
+              throw new Error("No refresh token");
+            }
+
+            const { accessToken } = await authService.refreshToken(refreshToken);
+            authUtils.setToken(accessToken);
+
+            if (originalRequest.headers) {
+              originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+            }
+            return axios(originalRequest);
+          } catch (refreshError) {
+            authUtils.clearAll();
+            setUser(null);
+            return Promise.reject(refreshError);
+          }
         }
+
+        return Promise.reject(error);
+      }
+    );
+
+    // 초기 인증 상태 설정
+    const initializeAuth = () => {
+      const token = authUtils.getToken();
+      const refreshToken = authUtils.getRefreshToken();
+      const storedUser = authUtils.getStoredUser();
+
+      if (token && refreshToken && storedUser) {
+        if (checkTokenExpiration(token) && authUtils.getRememberMe()) {
+          authService.refreshToken(refreshToken).catch(() => {
+            authUtils.clearAll();
+            setUser(null);
+          });
+        }
+        setUser(storedUser);
+      } else {
+        authUtils.clearAll();
+        setUser(null);
       }
     };
 
     initializeAuth();
+
+    return () => {
+      axios.interceptors.response.eject(interceptor);
+    };
   }, [setUser]);
 
   return <>{children}</>;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@
 import { Outlet, useLocation, Navigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { userState } from "@/store/auth";
+import { AuthNavigationHandler } from "./AuthNavigationHandler";
 import AuthHeader from "./AuthHeader";
 import MainHeader from "./MainHeader";
 
@@ -23,6 +24,7 @@ export default function Layout() {
 
   return (
     <div className="min-h-screen flex flex-col">
+      <AuthNavigationHandler />
       {isAuthPage && !isLoginPage ? <AuthHeader /> : null}
       {!isAuthPage && <MainHeader />}
       <main className={isLoginPage ? "flex-1" : "flex-1 pt-16"}>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,53 +1,89 @@
 // src/hooks/useAuth.ts
 import { useRecoilState } from "recoil";
 import { useNavigate } from "react-router-dom";
+import { useToast } from "@/contexts/useToast";
 import { userState, authUtils } from "@/store/auth";
 import { authService } from "@/services/auth";
-import type { LoginForm, SignupForm } from "@/types/auth";
+import { ApiError } from "@/utils/errorHandler";
+import { jwtDecode } from "jwt-decode";
+import type { LoginForm, SignupForm, User, TokenPayload } from "@/types/auth";
 
 export const useAuth = () => {
   const [user, setUser] = useRecoilState(userState);
   const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const extractUserFromToken = (token: string): User | null => {
+    try {
+      const decoded = jwtDecode<TokenPayload>(token);
+      return {
+        id: decoded.id,
+        email: decoded.email,
+        name: decoded.email.split("@")[0], // 이메일에서 임시로 이름 추출
+      };
+    } catch {
+      return null;
+    }
+  };
 
   const login = async (data: LoginForm, rememberMe?: boolean) => {
     try {
-      const response = await authService.login(data);
-      if (rememberMe) {
-        authUtils.setRememberMe(true);
+      const response = await authService.login(data, !!rememberMe);
+
+      // 토큰에서 사용자 정보 추출
+      const userData = extractUserFromToken(response.accessToken);
+      if (!userData) {
+        throw new Error("Invalid token");
       }
-      setUser(response.user);
-      authUtils.setStoredUser(response.user);
+
+      authUtils.setStoredUser(userData);
+      setUser(userData);
+      showToast("로그인이 완료되었습니다.", "success");
       navigate("/");
       return response;
     } catch (error) {
-      if (error instanceof Error) {
-        throw error;
+      if (error instanceof ApiError) {
+        showToast(error.message, "error");
+      } else {
+        showToast("로그인에 실패했습니다.", "error");
       }
-      throw new Error("로그인에 실패했습니다");
+      throw error;
     }
   };
 
   const signup = async (data: SignupForm) => {
     try {
-      const response = await authService.signup(data);
-      setUser(response.user);
-      authUtils.setStoredUser(response.user);
-      navigate("/");
-      return response;
+      await authService.signup(data);
+      showToast("회원가입이 완료되었습니다. 로그인해주세요.", "success");
+      navigate("/auth/login");
     } catch (error) {
-      if (error instanceof Error) {
-        throw error;
+      if (error instanceof ApiError) {
+        showToast(error.message, "error");
+      } else {
+        showToast("회원가입에 실패했습니다.", "error");
       }
-      throw new Error("회원가입에 실패했습니다");
+      throw error;
     }
   };
 
-  const logout = () => {
-    authUtils.removeToken();
-    authUtils.removeStoredUser();
-    authUtils.removeRememberMe();
-    setUser(null);
-    navigate("/auth/login");
+  const logout = async () => {
+    try {
+      await authService.logout();
+      authUtils.clearAll();
+      setUser(null);
+      showToast("로그아웃 되었습니다.", "success");
+      navigate("/auth/login");
+    } catch {  // '_' 파라미터 제거
+      authUtils.clearAll();
+      setUser(null);
+      showToast("로그아웃 중 오류가 발생했습니다.", "error");
+      navigate("/auth/login");
+    }
+  };
+
+  const isAuthenticated = () => {
+    const token = authUtils.getToken();
+    return !!token && !!user;
   };
 
   return {
@@ -55,6 +91,6 @@ export const useAuth = () => {
     login,
     signup,
     logout,
-    isAuthenticated: authService.isAuthenticated(),
+    isAuthenticated: isAuthenticated(),
   };
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,128 +1,115 @@
 // src/services/auth.ts
-import type { LoginForm, SignupForm, PasswordResetForm, AuthResponse } from '@/types/auth';
-import { loginWithDummy, authUtils } from '@/store/auth';
+import type { 
+  LoginForm, 
+  SignupForm, 
+  PasswordResetForm, 
+  AuthResponse
+} from '@/types/auth';
+import api from '@/utils/api';
+import { handleApiError } from '@/utils/errorHandler';
+import { authUtils } from '@/store/auth';
 
 class AuthService {
-  // API 엔드포인트 설정
-  private baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
-  private isDevelopment = process.env.NODE_ENV === 'development';
-
-  // 로그인
-  async login(data: LoginForm): Promise<AuthResponse> {
+  // 인증번호 전송 (회원가입)
+  async sendVerificationCode(name: string, email: string): Promise<void> {
     try {
-      if (this.isDevelopment) {
-        // 개발 환경에서는 더미 데이터 사용
-        const user = await loginWithDummy(data);
-        const dummyToken = 'dummy-token-' + Date.now();
-        authUtils.setToken(dummyToken);
-        return {
-          accessToken: dummyToken,
-          user,
-        };
-      }
-
-      // 프로덕션 환경에서는 실제 API 호출
-      const response = await fetch(`${this.baseUrl}/auth/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        throw new Error('Login failed');
-      }
-
-      const result = await response.json();
-      authUtils.setToken(result.accessToken);
-      return result;
+      await api.post('/api/users/email', { name, email });
     } catch (error) {
-      console.error('Login error:', error);
-      throw error;
+      throw handleApiError(error);
     }
   }
 
   // 회원가입
-  async signup(data: SignupForm): Promise<AuthResponse> {
+  async signup(data: SignupForm): Promise<void> {
     try {
-      if (this.isDevelopment) {
-        // 개발 환경에서는 더미 회원가입 처리
-        const mockUser = {
-          id: Date.now().toString(),
-          name: data.name,
-          email: data.email,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        };
-        const dummyToken = 'dummy-token-' + Date.now();
-        authUtils.setToken(dummyToken);
-        return {
-          accessToken: dummyToken,
-          user: mockUser,
-        };
-      }
+      await api.post('/api/users/signup', {
+        email: data.email,
+        verificationCode: data.verificationCode,
+        password: data.password,
+        confirmPassword: data.passwordConfirm,
+      });
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-      // 프로덕션 환경에서는 실제 API 호출
-      const response = await fetch(`${this.baseUrl}/auth/signup`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
+  // 로그인
+  async login(data: LoginForm, autoLogin: boolean): Promise<AuthResponse> {
+    try {
+      const response = await api.post<AuthResponse>('/api/users/login', {
+        email: data.email,
+        password: data.password,
+        autoLogin,
       });
 
-      if (!response.ok) {
-        throw new Error('Signup failed');
+      // 토큰 저장
+      const { accessToken, refreshToken } = response.data;
+      if (accessToken) {
+        authUtils.setToken(accessToken);
+        if (refreshToken) {
+          authUtils.setRefreshToken(refreshToken);
+        }
+        if (autoLogin) {
+          authUtils.setRememberMe(true);
+        }
       }
 
-      const result = await response.json();
-      authUtils.setToken(result.accessToken);
-      return result;
+      return response.data;
     } catch (error) {
-      console.error('Signup error:', error);
-      throw error;
+      throw handleApiError(error);
+    }
+  }
+
+  // 로그아웃
+  async logout(): Promise<void> {
+    try {
+      await api.post('/api/users/logout');
+      authUtils.clearAll();
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
+
+  // 비밀번호 재설정 인증번호 전송
+  async sendPasswordResetCode(email: string): Promise<void> {
+    try {
+      await api.post('/api/users/password/email', { email });
+    } catch (error) {
+      throw handleApiError(error);
     }
   }
 
   // 비밀번호 재설정
   async resetPassword(data: PasswordResetForm): Promise<void> {
     try {
-      if (this.isDevelopment) {
-        // 개발 환경에서는 더미 처리
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        return;
-      }
-
-      const response = await fetch(`${this.baseUrl}/auth/reset-password`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
+      await api.post('/api/users/password/reset', {
+        email: data.email,
+        verificationCode: data.verificationCode,
+        newPassword: data.newPassword,
+        confirmPassword: data.newPasswordConfirm,
       });
-
-      if (!response.ok) {
-        throw new Error('Password reset failed');
-      }
     } catch (error) {
-      console.error('Password reset error:', error);
-      throw error;
+      throw handleApiError(error);
     }
   }
 
-  // 토큰 관리는 authUtils로 위임
-  getToken(): string | null {
-    return authUtils.getToken();
-  }
+  // 토큰 갱신
+  async refreshToken(refreshToken: string): Promise<{ accessToken: string }> {
+    try {
+      const response = await api.post<{ accessToken: string }>('/api/users/token', { 
+        refreshToken 
+      });
+      
+      const { accessToken } = response.data;
+      if (accessToken) {
+        authUtils.setToken(accessToken);
+      }
 
-  removeToken(): void {
-    authUtils.removeToken();
-  }
-
-  // 인증 상태 확인
-  isAuthenticated(): boolean {
-    return !!this.getToken();
+      return response.data;
+    } catch (error) {
+      authUtils.clearAll();
+      throw handleApiError(error);
+    }
   }
 }
 

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,47 +1,23 @@
 // src/store/auth.ts
 import { atom } from "recoil";
-import type { User, LoginForm } from "@/types/auth";
+import type { User } from "@/types/auth";
 
 export const userState = atom<User | null>({
   key: "userState",
   default: null,
 });
 
-// 더미 유저 데이터
-const DUMMY_USERS: (User & { password: string })[] = [
-  {
-    id: "1",
-    name: "테스트",
-    email: "test@refhub.com",
-    password: "password123",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  },
-];
-
-// 더미 로그인 함수
-export const loginWithDummy = async (data: LoginForm): Promise<User> => {
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  const user = DUMMY_USERS.find(
-    (u) => u.email === data.email && u.password === data.password
-  );
-
-  if (!user) {
-    throw new Error("이메일 또는 비밀번호가 일치하지 않습니다.");
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { password, ...userWithoutPassword } = user;
-  return userWithoutPassword;
-};
-
 // 로컬 스토리지 관련 유틸리티 함수
 export const authUtils = {
-  // 토큰 관련
-  getToken: () => localStorage.getItem("token"),
-  setToken: (token: string) => localStorage.setItem("token", token),
-  removeToken: () => localStorage.removeItem("token"),
+  // 액세스 토큰 관련
+  getToken: () => localStorage.getItem("accessToken"),
+  setToken: (token: string) => localStorage.setItem("accessToken", token),
+  removeToken: () => localStorage.removeItem("accessToken"),
+  
+  // 리프레시 토큰 관련
+  getRefreshToken: () => localStorage.getItem("refreshToken"),
+  setRefreshToken: (token: string) => localStorage.setItem("refreshToken", token),
+  removeRefreshToken: () => localStorage.removeItem("refreshToken"),
   
   // 유저 정보 관련
   getStoredUser: (): User | null => {
@@ -63,7 +39,8 @@ export const authUtils = {
   
   // 초기화
   clearAll: () => {
-    localStorage.removeItem("token");
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
     localStorage.removeItem("user");
     localStorage.removeItem("remember-me");
   }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -24,12 +24,27 @@ export interface User {
   id: string;
   name: string;
   email: string;
-  createdAt: string;
-  updatedAt: string;
 }
 
-// API 응답 타입
-export interface AuthResponse {
+// API 응답 타입들
+export interface ApiResponse {
+  message: string;
+}
+
+export interface AuthResponse extends ApiResponse {
   accessToken: string;
-  user: User;
+  refreshToken?: string;
+  autoLogin: boolean;
+}
+
+export interface ApiErrorResponse {
+  error: string;
+}
+
+// Token 관련 타입
+export interface TokenPayload {
+  id: string;
+  email: string;
+  iat: number;
+  exp: number;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,56 @@
+// src/utils/api.ts
+import axios from 'axios';
+import { authUtils } from '@/store/auth';
+import { ERROR_MESSAGES, handleApiError } from './errorHandler';
+
+const api = axios.create({
+  baseURL: 'https://refhub.site',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  timeout: 10000, // 10초
+});
+
+// 요청 인터셉터
+api.interceptors.request.use(
+  (config) => {
+    const token = authUtils.getToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터
+api.interceptors.response.use(
+  (response) => response.data,
+  (error) => {
+    if (axios.isAxiosError(error)) {
+      if (error.code === 'ECONNABORTED') {
+        throw new Error(ERROR_MESSAGES.NETWORK_ERROR);
+      }
+
+      const status = error.response?.status;
+      switch (status) {
+        case 401:
+          throw new Error(ERROR_MESSAGES.UNAUTHORIZED);
+        case 403:
+          throw new Error(ERROR_MESSAGES.FORBIDDEN);
+        case 404:
+          throw new Error(ERROR_MESSAGES.NOT_FOUND);
+        case 422:
+          throw new Error(ERROR_MESSAGES.VALIDATION_ERROR);
+        case 500:
+          throw new Error(ERROR_MESSAGES.SERVER_ERROR);
+        default:
+          return handleApiError(error);
+      }
+    }
+
+    return handleApiError(error);
+  }
+);
+
+export default api;

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,44 @@
+// src/utils/errorHandler.ts
+import { AxiosError } from 'axios';
+import type { ApiErrorResponse } from '@/types/auth';
+
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const handleApiError = (error: unknown): never => {
+  if (error instanceof AxiosError) {
+    const status = error.response?.status || 500;
+    const data = error.response?.data as ApiErrorResponse;
+    
+    // API에서 반환하는 에러 메시지 사용
+    const message = data?.error || error.message || '알 수 없는 오류가 발생했습니다.';
+    
+    throw new ApiError(message, status);
+  }
+  
+  if (error instanceof Error) {
+    throw new ApiError(error.message, 500);
+  }
+  
+  throw new ApiError('알 수 없는 오류가 발생했습니다.', 500);
+};
+
+// 공통 에러 메시지
+export const ERROR_MESSAGES = {
+  NETWORK_ERROR: '네트워크 연결을 확인해주세요.',
+  SERVER_ERROR: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  UNAUTHORIZED: '로그인이 필요한 서비스입니다.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+  NOT_FOUND: '요청하신 리소스를 찾을 수 없습니다.',
+  VALIDATION_ERROR: '입력값을 확인해주세요.',
+  DEFAULT: '알 수 없는 오류가 발생했습니다.',
+} as const;


### PR DESCRIPTION
## 인증 API 연동 구현

### 변경사항
- 백엔드 인증 API 연동 구현
- JWT 토큰 기반 인증 처리 추가
- 사용자 정보 관리 로직 개선

### 주요 작업내용
1. API 응답 타입 정의 추가
   - AuthResponse, ApiErrorResponse 등 타입 정의
   - 토큰 페이로드 타입 추가

2. API 설정 및 에러 처리
   - axios 인스턴스 설정
   - 공통 에러 핸들러 구현
   - 토큰 갱신 인터셉터 추가

3. 인증 컴포넌트 구조 개선
   - AuthProvider 리팩토링
   - AuthNavigationHandler 추가
   - Layout 컴포넌트 개선

4. 인증 페이지 API 연동
   - 로그인/회원가입/비밀번호 재설정 페이지 API 연동
   - 토스트 메시지 처리 추가
   - 에러 핸들링 개선

### 테스트 방법
1. 회원가입
   - 이메일 인증 프로세스 확인
   - 유효성 검사 동작 확인

2. 로그인
   - 자동 로그인 기능 확인
   - 토큰 저장 확인

3. 비밀번호 재설정
   - 이메일 인증 프로세스 확인
   - 비밀번호 변경 확인

### 주의사항
- JWT 토큰 관리를 위해 jwt-decode 패키지가 추가되었습니다
- 백엔드 API 명세에 따라 응답 처리 방식이 변경되었습니다