### PR TITLE
feat: 인증 API 연동 구현 2

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -34,9 +34,9 @@ export default function LoginPage() {
     
     setIsLoading(true);
     try {
-      await authService.login(data, rememberMe);
+      const response = await authService.login(data, rememberMe);
+      showToast(response.message || "로그인이 완료되었습니다.", "success");
       navigate("/");
-      showToast("로그인이 완료되었습니다.", "success");
     } catch (error) {
       if (error instanceof Error) {
         showToast(error.message, "error");
@@ -79,6 +79,7 @@ export default function LoginPage() {
                   })}
                   error={errors.email?.message}
                   className="h-14"
+                  disabled={isLoading}
                 />
               </div>
 
@@ -92,6 +93,7 @@ export default function LoginPage() {
                   })}
                   error={errors.password?.message}
                   className="h-14"
+                  disabled={isLoading}
                 />
               </div>
             </div>
@@ -104,6 +106,7 @@ export default function LoginPage() {
                   checked={rememberMe}
                   onChange={(e) => setRememberMe(e.target.checked)}
                   className="h-4 w-4 accent-primary border-gray-300 rounded"
+                  disabled={isLoading}
                 />
                 <label htmlFor="remember-me" className="ml-2 text-sm text-[#676967]">
                   자동 로그인
@@ -112,6 +115,7 @@ export default function LoginPage() {
               <Link
                 to="/auth/reset-password"
                 className="text-sm text-[#676967] hover:text-primary"
+                tabIndex={isLoading ? -1 : 0}
               >
                 비밀번호를 잊으셨나요?
               </Link>
@@ -133,7 +137,11 @@ export default function LoginPage() {
 
           <div className="text-center mt-6">
             <span className="text-[#676967] text-sm">계정이 없으신가요? </span>
-            <Link to="/auth/signup" className="text-primary hover:text-primary-dark text-sm">
+            <Link 
+              to="/auth/signup" 
+              className="text-primary hover:text-primary-dark text-sm"
+              tabIndex={isLoading ? -1 : 0}
+            >
               회원가입
             </Link>
           </div>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,116 +1,107 @@
 // src/services/auth.ts
-import type { 
-  LoginForm, 
-  SignupForm, 
-  PasswordResetForm, 
-  AuthResponse
-} from '@/types/auth';
+import type { LoginForm, SignupForm, PasswordResetForm, LoginResponse } from '@/types/auth';
 import api from '@/utils/api';
 import { handleApiError } from '@/utils/errorHandler';
 import { authUtils } from '@/store/auth';
 
 class AuthService {
-  // 인증번호 전송 (회원가입)
-  async sendVerificationCode(name: string, email: string): Promise<void> {
-    try {
-      await api.post('/api/users/email', { name, email });
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+ async sendVerificationCode(name: string, email: string): Promise<void> {
+   try {
+     const response = await api.post("/users/email", { name, email });
+     return response.data;
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 회원가입
-  async signup(data: SignupForm): Promise<void> {
-    try {
-      await api.post('/api/users/signup', {
-        email: data.email,
-        verificationCode: data.verificationCode,
-        password: data.password,
-        confirmPassword: data.passwordConfirm,
-      });
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+ async signup(data: SignupForm): Promise<void> {
+   try {
+     const response = await api.post("/users/signup", {
+       email: data.email,
+       verificationCode: data.verificationCode,
+       password: data.password,
+       confirmPassword: data.passwordConfirm,
+     });
+     return response.data;
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 로그인
-  async login(data: LoginForm, autoLogin: boolean): Promise<AuthResponse> {
-    try {
-      const response = await api.post<AuthResponse>('/api/users/login', {
-        email: data.email,
-        password: data.password,
-        autoLogin,
-      });
+ async login(data: LoginForm, autoLogin: boolean): Promise<LoginResponse> {
+   try {
+     const response = await api.post<LoginResponse>("/users/login", {
+       email: data.email,
+       password: data.password,
+       autoLogin,
+     });
 
-      // 토큰 저장
-      const { accessToken, refreshToken } = response.data;
-      if (accessToken) {
-        authUtils.setToken(accessToken);
-        if (refreshToken) {
-          authUtils.setRefreshToken(refreshToken);
-        }
-        if (autoLogin) {
-          authUtils.setRememberMe(true);
-        }
-      }
+     if (response.data.accessToken) {
+       authUtils.setToken(response.data.accessToken);
+       if (response.data.refreshToken) {
+         authUtils.setRefreshToken(response.data.refreshToken);
+       }
+       if (autoLogin) {
+         authUtils.setRememberMe(true);
+       }
+     }
 
-      return response.data;
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+     return response.data;
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 로그아웃
-  async logout(): Promise<void> {
-    try {
-      await api.post('/api/users/logout');
-      authUtils.clearAll();
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+ async logout(): Promise<void> {
+   try {
+     await api.post("/users/logout");
+     authUtils.clearAll();
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 비밀번호 재설정 인증번호 전송
-  async sendPasswordResetCode(email: string): Promise<void> {
-    try {
-      await api.post('/api/users/password/email', { email });
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+ async sendPasswordResetCode(email: string): Promise<void> {
+   try {
+     const response = await api.post("/users/password/email", { email });
+     return response.data;
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 비밀번호 재설정
-  async resetPassword(data: PasswordResetForm): Promise<void> {
-    try {
-      await api.post('/api/users/password/reset', {
-        email: data.email,
-        verificationCode: data.verificationCode,
-        newPassword: data.newPassword,
-        confirmPassword: data.newPasswordConfirm,
-      });
-    } catch (error) {
-      throw handleApiError(error);
-    }
-  }
+ async resetPassword(data: PasswordResetForm): Promise<void> {
+   try {
+     const response = await api.post("/users/password/reset", {
+       email: data.email,
+       verificationCode: data.verificationCode,
+       newPassword: data.newPassword,
+       confirmPassword: data.newPasswordConfirm,
+     });
+     return response.data;
+   } catch (error) {
+     throw handleApiError(error);
+   }
+ }
 
-  // 토큰 갱신
-  async refreshToken(refreshToken: string): Promise<{ accessToken: string }> {
-    try {
-      const response = await api.post<{ accessToken: string }>('/api/users/token', { 
-        refreshToken 
-      });
-      
-      const { accessToken } = response.data;
-      if (accessToken) {
-        authUtils.setToken(accessToken);
-      }
+ async refreshToken(refreshToken: string): Promise<{ accessToken: string }> {
+   try {
+     const response = await api.post<{ accessToken: string }>(
+       "/users/token",
+       { refreshToken }
+     );
 
-      return response.data;
-    } catch (error) {
-      authUtils.clearAll();
-      throw handleApiError(error);
-    }
-  }
+     const { accessToken } = response.data;
+     if (accessToken) {
+       authUtils.setToken(accessToken);
+     }
+
+     return response.data;
+   } catch (error) {
+     authUtils.clearAll();
+     throw handleApiError(error);
+   }
+ }
 }
 
 export const authService = new AuthService();

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,5 +1,4 @@
 // src/types/auth.ts
-
 export interface LoginForm {
   email: string;
   password: string;
@@ -31,11 +30,20 @@ export interface ApiResponse {
   message: string;
 }
 
-export interface AuthResponse extends ApiResponse {
+export interface LoginResponse extends ApiResponse {
   accessToken: string;
   refreshToken?: string;
   autoLogin: boolean;
 }
+
+export interface TokenResponse {
+  accessToken: string;
+}
+
+// 빈 인터페이스 대신 type alias 사용
+export type SignupResponse = ApiResponse;
+export type EmailVerificationResponse = ApiResponse;
+export type PasswordResetResponse = ApiResponse;
 
 export interface ApiErrorResponse {
   error: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,20 +4,28 @@ import { authUtils } from '@/store/auth';
 import { ERROR_MESSAGES, handleApiError } from './errorHandler';
 
 const api = axios.create({
-  baseURL: 'https://refhub.site',
+  baseURL: 'https://api.refhub.site',  // 새로운 백엔드 도메인으로 변경
   headers: {
     'Content-Type': 'application/json',
+    'Accept': 'application/json'
   },
-  timeout: 10000, // 10초
+  timeout: 10000,
+  withCredentials: true
 });
 
 // 요청 인터셉터
 api.interceptors.request.use(
   (config) => {
+    // /api prefix 제거 (새로운 도메인에서는 불필요)
+    if (config.url?.startsWith('/api/')) {
+      config.url = config.url.substring(4);
+    }
+
     const token = authUtils.getToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
+
     return config;
   },
   (error) => Promise.reject(error)
@@ -25,31 +33,46 @@ api.interceptors.request.use(
 
 // 응답 인터셉터
 api.interceptors.response.use(
-  (response) => response.data,
+  (response) => {
+    if (!response.data) {
+      console.error('Empty response data:', response);
+      throw new Error(ERROR_MESSAGES.DEFAULT);
+    }
+    return response;
+  },
   (error) => {
+    console.error('API Error:', error);
+
     if (axios.isAxiosError(error)) {
       if (error.code === 'ECONNABORTED') {
         throw new Error(ERROR_MESSAGES.NETWORK_ERROR);
       }
 
-      const status = error.response?.status;
-      switch (status) {
-        case 401:
-          throw new Error(ERROR_MESSAGES.UNAUTHORIZED);
-        case 403:
-          throw new Error(ERROR_MESSAGES.FORBIDDEN);
-        case 404:
-          throw new Error(ERROR_MESSAGES.NOT_FOUND);
-        case 422:
-          throw new Error(ERROR_MESSAGES.VALIDATION_ERROR);
-        case 500:
-          throw new Error(ERROR_MESSAGES.SERVER_ERROR);
-        default:
-          return handleApiError(error);
+      if (error.response) {
+        const status = error.response.status;
+        const errorMessage = error.response.data?.error || error.response.data?.message;
+
+        switch (status) {
+          case 401:
+            authUtils.clearAll(); // 인증 에러시 로컬 스토리지 클리어
+            throw new Error(errorMessage || ERROR_MESSAGES.UNAUTHORIZED);
+          case 403:
+            throw new Error(errorMessage || ERROR_MESSAGES.FORBIDDEN);
+          case 404:
+            throw new Error(errorMessage || ERROR_MESSAGES.NOT_FOUND);
+          case 422:
+            throw new Error(errorMessage || ERROR_MESSAGES.VALIDATION_ERROR);
+          case 500:
+            throw new Error(errorMessage || ERROR_MESSAGES.SERVER_ERROR);
+          default:
+            throw new Error(errorMessage || ERROR_MESSAGES.DEFAULT);
+        }
       }
+
+      throw new Error(ERROR_MESSAGES.NETWORK_ERROR);
     }
 
-    return handleApiError(error);
+    throw handleApiError(error);
   }
 );
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 // vite.config.ts
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -9,5 +9,26 @@ export default defineConfig({
     alias: [
       { find: '@', replacement: path.resolve(__dirname, 'src') }
     ]
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://refhub.site',
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+        configure: (proxy) => {
+          proxy.on('error', (err) => {
+            console.log('proxy error', err);
+          });
+          proxy.on('proxyReq', (proxyReq, req) => {
+            console.log('Sending Request to the Target:', req.method, req.url);
+          });
+          proxy.on('proxyRes', (proxyRes, req) => {
+            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
+          });
+        },
+      }
+    }
   }
-})
+});


### PR DESCRIPTION
## 인증 API 연동 구현 2

### 변경사항
1. API 도메인 설정 변경
   - 백엔드 API 도메인을 api.refhub.site로 변경
   - CORS 관련 설정 추가
   - Vite 프록시 설정 업데이트

2. 인증 서비스 로직 개선
   - API 엔드포인트 경로 수정
   - 응답 데이터 처리 로직 개선
   - 토큰 관리 기능 강화

3. 타입 시스템 개선
   - API 응답 타입 명확화
   - 불필요한 인터페이스 제거
   - TokenResponse 타입 추가

4. 로그인 페이지 기능 개선
   - API 연동 로직 구현
   - 로딩 상태 처리
   - 에러 메시지 표시 개선

### 테스트 방법
1. 로그인 기능
   - 정상 로그인
   - 잘못된 계정 정보 입력
   - 자동 로그인 체크
   - 토큰 저장 확인

2. 에러 처리
   - 네트워크 오류
   - 인증 실패
   - 서버 오류

### 주의사항
- 환경 변수에서 API_URL 설정 필요
- 로컬 개발 환경에서 CORS 이슈 발생 가능성 있음