### PR TITLE
feat: 컬렉션 상세 페이지 구현 및 api 연동

### DIFF
--- a/src/components/collection/CollectionCard.tsx
+++ b/src/components/collection/CollectionCard.tsx
@@ -2,9 +2,16 @@
 import React, { useState, useEffect, useRef } from "react";
 import { CollectionCard as CollectionCardProps } from "../../types/collection";
 import { useRecoilState, useSetRecoilState } from "recoil";
-import { floatingModeState, modalState, alertState } from "@/store/collection";
+import {
+  floatingModeState,
+  modalState,
+  alertState,
+  DropState,
+  shareModalState,
+} from "@/store/collection";
 import { collectionService } from "@/services/collection";
 import { useToast } from "@/contexts/useToast";
+import { useNavigate } from "react-router-dom";
 import folder from "@/assets/images/folder.svg";
 import {
   Star,
@@ -23,13 +30,16 @@ const CollectionCard: React.FC<CollectionCardProps> = ({
   isFavorite,
   isShared,
 }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const addRef = useRef<HTMLDivElement>(null);
   const [isChecked, setIsChecked] = useState(false);
   const [modeValue, setModeValue] = useRecoilState(floatingModeState);
+  const setDrop = useSetRecoilState(DropState);
   const setModalOpen = useSetRecoilState(modalState);
   const setAlert = useSetRecoilState(alertState);
+  const setShareOpen = useSetRecoilState(shareModalState);
 
   useEffect(() => {
     setIsChecked(false);
@@ -89,7 +99,18 @@ const CollectionCard: React.FC<CollectionCardProps> = ({
       massage: text,
       isVisible: true,
       type: "collection",
+      title: "",
     });
+  };
+
+  const handleDetail = () => {
+    setDrop({
+      sortType: "latest",
+      searchType: "all",
+      searchWord: "",
+      collections: [],
+    });
+    navigate(`/collections/${_id}`);
   };
 
   return (
@@ -142,7 +163,10 @@ const CollectionCard: React.FC<CollectionCardProps> = ({
                 <Trash2 className="w-5 h-5 stroke-[#f65063]" />
                 <p className="text-black text-sm font-normal">삭제</p>
               </li>
-              <li className="inline-flex items-center gap-2 px-4 py-2 text-gray-700 text-center rounded cursor-pointer hover:bg-gray-200">
+              <li
+                onClick={() => setShareOpen({ isOpen: true })}
+                className="inline-flex items-center gap-2 px-4 py-2 text-gray-700 text-center rounded cursor-pointer hover:bg-gray-200"
+              >
                 <Share2 className="w-5 h-5 stroke-[#676967]" />
                 <p className="text-black text-sm font-normal">공유</p>
               </li>
@@ -163,7 +187,10 @@ const CollectionCard: React.FC<CollectionCardProps> = ({
             <Star className="w-6 h-6" />
           )}
         </button>
-        <h2 className="text-lg font-bold text-gray-800 flex-1 truncate">
+        <h2
+          onClick={handleDetail}
+          className="text-lg font-bold text-gray-800 flex-1 truncate hover:cursor-pointer hover:underline"
+        >
           {title}
         </h2>
         {isShared && <Users className="w-5 h-5 stroke-gray-700 mr-5" />}

--- a/src/components/collection/Modal.tsx
+++ b/src/components/collection/Modal.tsx
@@ -1,37 +1,52 @@
 // src/components/collection/Modal.tsx
-import { useState, useEffect } from "react";
-import { X, CircleX } from "lucide-react";
+import { useState } from "react";
+import { X, CircleX, ChevronDown, ChevronUp } from "lucide-react";
 import { useToast } from "@/contexts/useToast";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { modalState, collectionState } from "@/store/collection";
+import { modalState, collectionState, alertState } from "@/store/collection";
 import { collectionService } from "@/services/collection";
 
-const Modal: React.FC = () => {
-  const types = {
+interface ModalProps {
+  type: string;
+}
+
+const Modal: React.FC<ModalProps> = ({ type }) => {
+  const types: { [key: string]: string[] } = {
     create: ["컬렉션 생성", "생성", "컬렉션의 제목을 입력해 주세요."],
     update: ["컬렉션 수정", "수정 완료"],
+    move: ["컬렉션 이동", "이동"],
   };
   const [isOpen, setIsOpen] = useRecoilState(modalState);
-  const [inputValue, setInputValue] = useState("");
+  const [alert, setAlert] = useRecoilState(alertState);
+  const [dropOpen, setdropOpen] = useState({
+    open: false,
+    value: "컬렉션을 선택해주세요.",
+  });
   const { showToast } = useToast();
   const collectiondata = useRecoilValue(collectionState);
 
-  useEffect(() => {
-    setInputValue(isOpen.type === "update" ? isOpen.title : "");
-  }, [isOpen]);
-
   const handleClick = async () => {
     try {
-      if (collectiondata?.data?.some((item) => item.title === inputValue)) {
-        showToast("이미 동일한 이름의 컬렉션이 있습니다.", "error");
-      } else if (isOpen.type === "create") {
-        await collectionService.createCollection(inputValue);
-        showToast("컬렉션이 생성되었습니다.", "success");
-        setIsOpen((prev) => ({ ...prev, isOpen: false }));
+      if (type !== "move") {
+        if (collectiondata?.data?.some((item) => item.title === isOpen.title)) {
+          showToast("이미 동일한 이름의 컬렉션이 있습니다.", "error");
+        } else if (isOpen.type === "create") {
+          await collectionService.createCollection(isOpen.title);
+          showToast("컬렉션이 생성되었습니다.", "success");
+          setIsOpen((prev) => ({ ...prev, isOpen: false }));
+        } else {
+          await collectionService.updateCollection(isOpen.id, isOpen.title);
+          showToast("컬렉션이 수정되었습니다.", "success");
+          setIsOpen((prev) => ({ ...prev, isOpen: false }));
+        }
       } else {
-        await collectionService.updateCollection(isOpen.id, inputValue);
-        showToast("컬렉션이 수정되었습니다.", "success");
-        setIsOpen((prev) => ({ ...prev, isOpen: false }));
+        setAlert((prev) => ({
+          ...prev,
+          type: "move",
+          massage: "선택한 레퍼런스의 컬렉션을 이동하시겠습니까?",
+          isVisible: true,
+          title: dropOpen.value,
+        }));
       }
     } catch (error) {
       if (error instanceof Error) {
@@ -42,8 +57,6 @@ const Modal: React.FC = () => {
     }
   };
 
-  useEffect(() => {}, []);
-
   return (
     <div className="flex fixed top-0 left-0 w-full h-full bg-black/60 z-20 items-center justify-center">
       <div className="flex flex-col items-center w-[520px] h-[294px] py-6 px-8 relative bg-[#f9faf9] rounded-2xl">
@@ -51,32 +64,74 @@ const Modal: React.FC = () => {
           className="absolute w-9 h-9 top-6 right-6 stroke-gray-700 hover: cursor-pointer"
           onClick={() => setIsOpen((prev) => ({ ...prev, isOpen: false }))}
         />
-        <p className="text-black text-2xl font-semibold">
-          {isOpen.type === "create" ? types["create"][0] : types["update"][0]}
-        </p>
-        <p className="text-xl font-semibold mt-8 w-full">컬렉션 명</p>
-        <div className="relative">
-          {inputValue.length > 0 && (
-            <CircleX
-              className="absolute top-8 right-5 w-6 h-6 fill-gray-700 stroke-white hover: cursor-pointer"
-              onClick={() => setInputValue("")}
+        <p className="text-black text-2xl font-semibold">{types[type][0]}</p>
+        {type !== "move" ? (
+          <p className="text-xl font-semibold mt-8 w-full">컬렉션 명</p>
+        ) : (
+          <p className="text-base font-normal mt-8">{`선택한 ${alert.ids.length}개의 레퍼런스를 옮길 컬렉션을 선택해주세요.`}</p>
+        )}
+        {type !== "move" ? (
+          <div className="relative">
+            {isOpen.title.length > 0 && (
+              <CircleX
+                className="absolute top-8 right-5 w-6 h-6 fill-gray-700 stroke-white hover: cursor-pointer"
+                onClick={() => setIsOpen((prev) => ({ ...prev, title: "" }))}
+              />
+            )}
+            <input
+              type="text"
+              placeholder={isOpen.type === "create" ? types["create"][2] : ""}
+              value={isOpen.title}
+              maxLength={20}
+              onChange={(e) =>
+                setIsOpen((prev) => ({ ...prev, title: e.target.value }))
+              }
+              className=" w-[456px] mt-4 py-4 px-5 bg-white rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50"
             />
-          )}
-          <input
-            type="text"
-            placeholder={isOpen.type === "create" ? types["create"][2] : ""}
-            value={inputValue}
-            maxLength={20}
-            onChange={(e) => setInputValue(e.target.value)}
-            className=" w-[456px] mt-4 py-4 px-5 bg-white rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50"
-          />
-        </div>
+          </div>
+        ) : (
+          <div className="relative text-base bg-white rounded-lg border border-gray-200 w-full mt-8">
+            <div
+              className={`flex items-center justify-between pl-5 pr-4 py-[13px] cursor-pointer text-gray-700 font-normal`}
+              onClick={() =>
+                setdropOpen((prev) => ({ ...prev, open: !prev.open }))
+              }
+              tabIndex={0}
+            >
+              {dropOpen.value}
+              {dropOpen.open ? (
+                <ChevronUp className="w-6 h-6 stroke-gray-700" />
+              ) : (
+                <ChevronDown className="w-6 h-6 stroke-gray-700" />
+              )}
+            </div>
+            {dropOpen.open && (
+              <ul className="flex flex-col absolute w-full bg-white p-4 gap-4 border border-gray-200 rounded-lg shadow-[0px_0px_10px_0px_rgba(181,184,181,0.20)] z-10">
+                {collectiondata.data.map((option, index) => (
+                  <li
+                    key={index}
+                    className="flex items-center gap-2 text-gray-700 text-base font-nomal cursor-pointer hover:text-primary hover:font-semibold"
+                    onClick={() =>
+                      setdropOpen({ open: false, value: option.title })
+                    }
+                  >
+                    {option.title}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
         <button
           onClick={handleClick}
-          disabled={inputValue.length === 0}
+          disabled={
+            type !== "move"
+              ? isOpen.title.length === 0
+              : dropOpen.value === "컬렉션을 선택해주세요."
+          }
           className="w-full mt-6 p-3.5 flex justify-center bg-primary rounded-lg text-[#F9FAF9] text-lg font-bold transition-colors duration-200 hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-gray-500"
         >
-          {isOpen.type === "create" ? types["create"][1] : types["update"][1]}
+          {types[type][1]}
         </button>
       </div>
     </div>

--- a/src/components/collection/ShareModal.tsx
+++ b/src/components/collection/ShareModal.tsx
@@ -1,0 +1,87 @@
+// src/components/collection/ShareModal.tsx
+import { useState } from "react";
+import { X, CircleX } from "lucide-react";
+import { useRecoilState } from "recoil";
+import { shareModalState } from "@/store/collection";
+
+const ShareModal: React.FC = () => {
+  const [, setIsOpen] = useRecoilState(shareModalState);
+  const [isShare, setIsShare] = useState(false);
+  const [email, setEmail] = useState("");
+
+  const handleClick = async () => {
+    //
+  };
+
+  return (
+    <div className="flex fixed top-0 left-0 w-full h-full bg-black/60 z-20 items-center justify-center">
+      <div className="flex flex-col items-center w-[520px] py-6 px-8 relative bg-[#f9faf9] rounded-2xl">
+        <X
+          className="absolute w-9 h-9 top-6 right-6 stroke-gray-700 hover: cursor-pointer"
+          onClick={() => setIsOpen({ isOpen: false })}
+        />
+        <p className="text-black text-2xl font-semibold">컬렉션 공유</p>
+
+        <p className="text-base font-normal mt-8 text-center">
+          이 컬렉션을 공유하고 함께 자료를 정리해보세요. <br />
+          공유된 사용자 모두 자료를 추가, 삭제, 수정할 수 있어요.
+        </p>
+
+        <div
+          className={`w-full h-14 flex relative mt-8 items-center bg-gray-100 rounded-[50px] border border-gray-200 text-lg font-bold cursor-pointer`}
+          onClick={() => setIsShare((prev) => !prev)}
+        >
+          <div
+            className={`w-[50%] h-12 bg-primary rounded-[50px] transform transition-transform duration-500
+        ${isShare ? "translate-x-56" : "translate-x-0.5"}`}
+          />
+          <p
+            className={`absolute left-[85px] transition-colors ${
+              isShare ? "text-primary" : "text-white"
+            }`}
+          >
+            나만보기
+          </p>
+          <p
+            className={`absolute right-[85px] transition-colors ${
+              isShare ? "text-white" : "text-primary"
+            }`}
+          >
+            공유하기
+          </p>
+        </div>
+
+        {isShare && (
+          <div className="mt-8 text-gray-700 text-lg font-semibold w-full">
+            <p>컬렉션 멤버</p>
+            <p>추가하기</p>
+            <div className="relative flex gap-2">
+              {email.length > 0 && (
+                <CircleX
+                  className="absolute top-5 right-24 w-6 h-6 fill-gray-700 stroke-white hover: cursor-pointer"
+                  onClick={() => setEmail("")}
+                />
+              )}
+              <input
+                type="text"
+                placeholder="추가할 멤버의 이메일을 입력해 주세요."
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className=" w-[456px] mt-2 py-3 px-5 bg-white text-base font-normal rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50"
+              />
+              <button
+                onClick={handleClick}
+                disabled={email.length === 0}
+                className="w-[100px] mt-2 flex justify-center items-center bg-primary rounded-lg text-white font-bold transition-colors duration-200 hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-gray-500"
+              >
+                초대
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ShareModal;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -28,7 +28,7 @@ export default function Layout() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-[#F9FAF9]">
       {isAuthPage && !isLoginPage ? <AuthHeader /> : null}
       {!isAuthPage && <MainHeader />}
       <main className="flex-1">

--- a/src/components/reference/ReferenceCard.tsx
+++ b/src/components/reference/ReferenceCard.tsx
@@ -1,44 +1,45 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Reference as ReferenceCardProps } from "../../types/reference";
-import { EllipsisVertical, Users, PencilLine, Trash2 } from "lucide-react";
+import {
+  EllipsisVertical,
+  Users,
+  PencilLine,
+  Trash2,
+  Image,
+} from "lucide-react";
 import {
   floatingModeState,
   collectionState,
   alertState,
 } from "@/store/collection";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import folder from "@/assets/images/folder.svg";
 
 const ReferenceCard: React.FC<ReferenceCardProps> = ({
   _id,
   createAndShare,
-  collectionId,
   title,
   keywords,
   previewURLs,
   createdAt,
+  collectionTitle,
 }) => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const addRef = useRef<HTMLDivElement>(null);
+  const date = new Date(createdAt);
+  const formattedDate = `${date.getFullYear()}.${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")}.${date.getDate().toString().padStart(2, "0")}`;
   const collectionData = useRecoilValue(collectionState);
-  const [collectionTitle, setCollectionTitle] = useState<string | null>(null);
   const [modeValue, setModeValue] = useRecoilState(floatingModeState);
   const setAlert = useSetRecoilState(alertState);
   const [isChecked, setIsChecked] = useState(false);
 
   useEffect(() => {
-    if (collectionData?.data?.length > 0) {
-      const collection = collectionData.data.find((item) => item._id === collectionId);
-      setCollectionTitle(collection?.title || null);
-    }
-  }, [collectionData, collectionId]);
-
-  useEffect(() => {
     setIsChecked(false);
     setModeValue((prev) => ({ ...prev, checkItems: [] }));
-  }, [modeValue.isMove, modeValue.isDelete, setModeValue]);
+  }, [modeValue.isMove, modeValue.isDelete]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -56,7 +57,7 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
     setIsChecked(e.target.checked);
     setModeValue((prev) => ({
       ...prev,
-      isShared: [...prev.isShared, createAndShare],
+      isShared: [...prev.isShared, createAndShare ?? false],
       checkItems: prev.checkItems.includes(e.target.id)
         ? prev.checkItems.filter((i) => i !== e.target.id)
         : [...prev.checkItems, e.target.id],
@@ -65,7 +66,9 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
 
   const handleDelete = () => {
     const text = createAndShare
-      ? `${collectionTitle || '선택한'} 컬렉션의 다른 사용자와 공유 중인 ${title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`
+      ? `${
+          collectionTitle || "선택한"
+        } 컬렉션의 다른 사용자와 공유 중인 ${title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`
       : `${title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`;
 
     setAlert({
@@ -73,6 +76,7 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
       massage: text,
       isVisible: true,
       type: "reference",
+      title: "",
     });
     setIsOpen(false);
   };
@@ -157,7 +161,7 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
 
       <h2 className="flex flex-row gap-2 items-center text-base font-normal text-gray-500 mt-4 mb-1 mr-4">
         {createAndShare && <Users className="w-5 h-5 stroke-gray-700" />}
-        <p className="flex-1 truncate">{collectionTitle || '불러오는 중...'}</p>
+        <p className="flex-1 truncate">{collectionTitle || "불러오는 중..."}</p>
       </h2>
 
       <p
@@ -179,9 +183,9 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
       </div>
 
       <div className="mb-2 min-h-[152px]">
-        {previewURLs?.length > 0 ? (
+        {(previewURLs ?? []).length > 0 ? (
           <div className="grid grid-cols-2 gap-2">
-            {previewURLs.slice(0, 4).map((image, index) => (
+            {(previewURLs ?? []).slice(0, 4).map((image, index) => (
               <img
                 key={`${image}-${index}`}
                 src={image}
@@ -191,17 +195,14 @@ const ReferenceCard: React.FC<ReferenceCardProps> = ({
             ))}
           </div>
         ) : (
-          <div className="bg-gray-100 w-full py-4 flex justify-center rounded-lg flex-col items-center gap-5">
-            <img src={folder} alt="Empty folder" className="w-[54%]" />
-            <p className="text-gray-700 text-sm font-normal">
-              아직 레퍼런스가 없어요.
-            </p>
+          <div className="bg-gray-100 w-full h-[152px] py-4 flex justify-center rounded-lg flex-col items-center gap-5">
+            <Image className="w-[80px] h-[80px] stroke-primary" />
           </div>
         )}
       </div>
 
       <p className="text-right text-gray-500 text-xs font-normal mb-2">
-        {createdAt}
+        {formattedDate}
       </p>
     </div>
   );

--- a/src/components/reference/ReferenceList.tsx
+++ b/src/components/reference/ReferenceList.tsx
@@ -23,12 +23,17 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
   const collectionData = useRecoilValue(collectionState);
   const setAlert = useSetRecoilState(alertState);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-  const menuRefs = useRef<{ [key: string]: HTMLTableDataCellElement | null }>({});
+  const menuRefs = useRef<{ [key: string]: HTMLTableDataCellElement | null }>(
+    {}
+  );
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (openMenuId && menuRefs.current[openMenuId] && 
-          !menuRefs.current[openMenuId]?.contains(event.target as Node)) {
+      if (
+        openMenuId &&
+        menuRefs.current[openMenuId] &&
+        !menuRefs.current[openMenuId]?.contains(event.target as Node)
+      ) {
         setOpenMenuId(null);
       }
     };
@@ -39,7 +44,7 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
   }, [openMenuId]);
 
   const handleRowClick = (id: string, event: React.MouseEvent) => {
-    if ((event.target as HTMLElement).closest('.more-button')) {
+    if ((event.target as HTMLElement).closest(".more-button")) {
       return;
     }
     navigate(`/references/${id}`);
@@ -49,7 +54,7 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
     const collectionTitle = collectionData.data.find(
       (i) => i._id === item.collectionId
     )?.title;
-    
+
     const text = item.createAndShare
       ? `${collectionTitle} 컬렉션의 다른 사용자와 공유 중인 ${item.title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`
       : `${item.title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`;
@@ -59,6 +64,7 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
       massage: text,
       isVisible: true,
       type: "reference",
+      title: "",
     });
     setOpenMenuId(null);
   };
@@ -108,10 +114,17 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
                 ))}
               </div>
             </td>
-            <td className="py-4">{item.createdAt}</td>
-            <td 
+            <td className="py-4">{`${new Date(item.createdAt).getFullYear()}.${(
+              new Date(item.createdAt).getMonth() + 1
+            )
+              .toString()
+              .padStart(2, "0")}.${new Date(item.createdAt)
+              .getDate()
+              .toString()
+              .padStart(2, "0")}`}</td>
+            <td
               className="relative py-4"
-              ref={(el) => menuRefs.current[item._id] = el}
+              ref={(el) => (menuRefs.current[item._id] = el)}
             >
               <div className="more-button flex justify-center">
                 <button

--- a/src/pages/collection/CollectionDetailPage.tsx
+++ b/src/pages/collection/CollectionDetailPage.tsx
@@ -1,9 +1,249 @@
 // src/pages/collection/CollectionDetailPage.tsx
+import { useParams, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useToast } from "@/contexts/useToast";
+import { FilePlus, LayoutGrid, Text, Users } from "lucide-react";
+import FloatingButton from "@/components/common/FloatingButton";
+import { referenceService } from "@/services/reference";
+import { Reference } from "@/types/reference";
+import {
+  DropState,
+  modalState,
+  collectionState,
+  alertState,
+  shareModalState,
+} from "@/store/collection";
+import { useRecoilValue, useRecoilState } from "recoil";
+import Dropdown from "@/components/common/Dropdown";
+import ReferenceCard from "@/components/reference/ReferenceCard";
+import ReferenceList from "@/components/reference/ReferenceList";
+import Modal from "@/components/collection/Modal";
+import Alert from "@/components/common/Alert";
+import ShareModal from "@/components/collection/ShareModal";
+import { collectionService } from "@/services/collection";
+import { ReferenceListItem } from "../reference/ReferenceListPage";
+
 export default function CollectionDetailPage() {
+  const { collectionId } = useParams();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const [view, setView] = useState("card");
+  const sort = useRecoilValue(DropState);
+  const shareModal = useRecoilValue(shareModalState);
+  const [alert, setAlert] = useRecoilState(alertState);
+  const [collectionDatas, setCollectionDatas] = useRecoilState(collectionState);
+  const [collectionData, setCollectionData] = useState(
+    collectionDatas.data.find((item) => item._id === collectionId)
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [modal, setModal] = useRecoilState(modalState);
+  const [referenceData, setReferenceData] = useState<ReferenceListItem[]>([]);
+
+  useEffect(() => {
+    const collectionParams = {
+      page: 1,
+      sortBy: sort.sortType,
+      search: sort.searchWord,
+    };
+    const getCollection = async () => {
+      try {
+        const data = await collectionService.getCollectionList(
+          collectionParams
+        );
+        setCollectionDatas(data);
+        setCollectionData(data.data.find((item) => item._id === collectionId));
+      } catch (error) {
+        if (error instanceof Error) {
+          showToast(error.message, "error");
+        } else {
+          showToast("컬렉션 가져오기를 실패했습니다.", "error");
+        }
+      }
+    };
+    getCollection();
+  }, [modal.isOpen]);
+
+  useEffect(() => {
+    const loadReferences = async () => {
+      setIsLoading(true);
+      try {
+        const params = {
+          sortBy: sort.sortType,
+          search: sort.searchWord,
+          collection: collectionData?.title || "",
+          filterBy: sort.searchType,
+          view: view,
+          mode: "home",
+        };
+
+        const response = await referenceService.getReferenceList(params);
+
+        // 데이터가 있는지 확인
+        if (!response.data) {
+          console.log("No data in response");
+          setReferenceData([]);
+          return;
+        }
+
+        // API 응답에서 데이터 변환
+        const transformedData: ReferenceListItem[] = response.data.map(
+          (reference) => {
+            const files = reference.files || [];
+            const previewURLs = files
+              .filter((file) => file && file.type === "image")
+              .flatMap((file) => file.previewURLs || [])
+              .slice(0, 4);
+
+            return {
+              _id: reference._id,
+              createAndShare: reference.createAndShare,
+              collectionId: reference.collectionId,
+              collectionTitle: collectionDatas.data.find(
+                (item) => item._id === reference.collectionId
+              )?.title,
+              title: reference.title,
+              keywords: reference.keywords,
+              previewURLs,
+              createdAt: reference.createdAt,
+              files: files.map((file) => ({
+                _id: file._id || file.path,
+                type: file.type,
+                path: file.path,
+                size: file.size,
+                previewURL: file.previewURL,
+                previewURLs: file.previewURLs,
+              })),
+            };
+          }
+        );
+
+        setReferenceData(transformedData);
+      } catch (error) {
+        console.error("Error loading references:", error); // 에러 상세 정보 확인
+        if (error instanceof Error) {
+          showToast(error.message, "error");
+        } else {
+          showToast("레퍼런스 데이터를 불러오는데 실패했습니다.", "error");
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadReferences();
+  }, [sort, view, alert, collectionData]);
+
+  const handleDelete = () => {
+    let text = "";
+    if (collectionData?.isShared) {
+      text = `공유 중인 ${collectionData.title} 컬렉션을 삭제하시겠습니까? \n컬렉션 내 모든 레퍼런스가 삭제되며, \n복구할 수 없습니다.`;
+    } else if (collectionData?.refCount === 0) {
+      text = `${collectionData.title} 컬렉션을 삭제하시겠습니까?`;
+    } else {
+      text = `${collectionData?.title} 컬렉션을 삭제하시겠습니까? \n컬렉션 내 모든 레퍼런스가 삭제되며, \n복구할 수 없습니다.`;
+    }
+    setAlert({
+      ids: [collectionData?._id || ""],
+      massage: text,
+      isVisible: true,
+      type: "collectionDetail",
+      title: "",
+    });
+  };
+
+  const viewStyles = (id: string) =>
+    `w-[50px] h-[50px] p-[9px] rounded-full overflow-visible hover:cursor-pointer ${
+      view === id
+        ? "bg-primary stroke-gray-100"
+        : "bg-white stroke-gray-700 border border-gray-200"
+    }`;
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">컬렉션 상세</h1>
-      <p>개발 중입니다.</p>
+    <div className="font-sans">
+      {modal.isOpen && <Modal type={modal.type} />}
+      {shareModal.isOpen && <ShareModal />}
+      {alert.isVisible && <Alert message={alert.massage} />}
+      {referenceData?.length > 0 && <FloatingButton type="collectionDetail" />}
+      <div className="flex flex-col max-w-7xl w-full px-4 sm:px-6 lg:px-8 mx-auto">
+        <div className="flex items-center justify-between mt-12 pb-6 border-b border-gray-400">
+          <p className="flex items-center text-primary text-3xl font-bold gap-4">
+            {collectionData?.isShared && (
+              <Users className="w-9 h-9 stroke-primary" />
+            )}
+            {collectionData?.title}
+          </p>
+          <div className="flex text-lg font-bold gap-1.5">
+            <button
+              className="px-8 py-3 bg-white rounded-[50px] border border-gray-200 text-[#f65063] hover:bg-gray-100"
+              onClick={handleDelete}
+            >
+              컬렉션 삭제
+            </button>
+            <button
+              className="px-8 py-3 bg-primary rounded-[50px] text-[#F9FAF9] hover:bg-primary-dark"
+              onClick={() =>
+                setModal({
+                  id: collectionId ? collectionId.toString() : "",
+                  title: collectionData?.title || "",
+                  isOpen: true,
+                  type: "update",
+                })
+              }
+            >
+              수정
+            </button>
+          </div>
+        </div>
+        <div className="flex items-center justify-between mt-10 mb-6">
+          <Dropdown type="array" />
+          <div className="flex gap-2">
+            <LayoutGrid
+              className={viewStyles("card")}
+              onClick={() => setView("card")}
+            />
+            <Text
+              className={viewStyles("list")}
+              onClick={() => setView("list")}
+            />
+          </div>
+        </div>
+        {referenceData.length > 0 ? (
+          view === "card" ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6">
+              {referenceData.map((data) => (
+                <ReferenceCard key={data._id} {...(data as Reference)} />
+              ))}
+            </div>
+          ) : (
+            <ReferenceList items={referenceData as Reference[]} />
+          )
+        ) : (
+          <div className="flex flex-col items-center">
+            <p className="text-gray-700 font-semibold text-2xl text-center mt-44 mb-6">
+              {sort.searchWord.length > 0
+                ? `검색 결과가 없어요.\n다른 검색어로 시도해 보세요!`
+                : `아직 추가된 레퍼런스가 없어요.\n자료를 추가해보세요!`}
+            </p>
+            {sort.searchWord.length === 0 && (
+              <button
+                onClick={() => navigate("/references/new")}
+                className="flex w-fit px-12 py-4 gap-3 rounded-full bg-primary hover:bg-primary-dark"
+              >
+                <FilePlus className="w-10 h-10 stroke-white" />
+                <p className="text-white text-3xl font-bold">레퍼런스 추가</p>
+              </button>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/collection/CollectionPage.tsx
+++ b/src/pages/collection/CollectionPage.tsx
@@ -6,6 +6,7 @@ import {
   DropState,
   collectionState,
   alertState,
+  shareModalState,
 } from "@/store/collection";
 import { collectionService } from "@/services/collection";
 import FloatingButton from "@/components/common/FloatingButton";
@@ -16,6 +17,7 @@ import { useToast } from "@/contexts/useToast";
 import Pagination from "@/components/collection/Pagination";
 import Modal from "@/components/collection/Modal";
 import Alert from "@/components/common/Alert";
+import ShareModal from "@/components/collection/ShareModal";
 
 const CollectionPage: React.FC = () => {
   const { showToast } = useToast();
@@ -23,7 +25,9 @@ const CollectionPage: React.FC = () => {
   const sort = useRecoilValue(DropState);
   const [modal, setModal] = useRecoilState(modalState);
   const alert = useRecoilValue(alertState);
+  const shareModal = useRecoilValue(shareModalState);
   const [collectionData, setCollectionData] = useRecoilState(collectionState);
+  const [totalPage, setTotalPage] = useState<number>(1);
 
   useEffect(() => {
     const params = {
@@ -35,6 +39,7 @@ const CollectionPage: React.FC = () => {
       try {
         const data = await collectionService.getCollectionList(params);
         setCollectionData(data || {});
+        setTotalPage(data.totalPages);
       } catch (error) {
         if (error instanceof Error) {
           showToast(error.message, "error");
@@ -51,7 +56,8 @@ const CollectionPage: React.FC = () => {
   };
   return (
     <div className="font-sans">
-      {modal.isOpen && <Modal />}
+      {modal.isOpen && <Modal type={modal.type} />}
+      {shareModal.isOpen && <ShareModal />}
       {alert.isVisible && <Alert message={alert.massage} />}
       {collectionData?.data?.length > 0 && <FloatingButton type="collection" />}
       <div className="flex flex-col max-w-7xl w-full px-4 sm:px-6 lg:px-8 mx-auto">
@@ -92,7 +98,7 @@ const CollectionPage: React.FC = () => {
         )}
         <Pagination
           currentPage={currentPage}
-          totalPage={collectionData.totalPages}
+          totalPage={totalPage}
           setPage={setCurrentPage}
         />
       </div>

--- a/src/pages/reference/ReferenceEditPage.tsx
+++ b/src/pages/reference/ReferenceEditPage.tsx
@@ -9,10 +9,6 @@ import { Loader } from "lucide-react";
 import type { CollectionCard } from "@/types/collection";
 import type { CreateReferenceFile } from "@/types/reference";
 
-interface RouteParams {
-  referenceId: string; // URL 파라미터 이름을 router 설정과 일치하도록 변경
-}
-
 interface FormData {
   collection: string;
   title: string;
@@ -22,6 +18,7 @@ interface FormData {
 }
 
 export default function ReferenceEditPage() {
+  type RouteParams = Record<string, string | undefined>;
   const { referenceId } = useParams<RouteParams>();
   const navigate = useNavigate();
   const { showToast } = useToast();
@@ -62,15 +59,17 @@ export default function ReferenceEditPage() {
         console.log("Received reference data:", reference);
 
         // 파일 데이터 변환
-        const convertedFiles: CreateReferenceFile[] = reference.files.map((file) => ({
-          id: file._id,
-          type: file.type,
-          content:
-            file.type === "link"
-              ? file.path
-              : file.previewURL || file.previewURLs?.[0] || "",
-          name: file.path.split("/").pop() || "",
-        }));
+        const convertedFiles: CreateReferenceFile[] = reference.files.map(
+          (file) => ({
+            id: file._id,
+            type: file.type,
+            content:
+              file.type === "link"
+                ? file.path
+                : file.previewURL || file.previewURLs?.[0] || "",
+            name: file.path.split("/").pop() || "",
+          })
+        );
 
         // 폼 데이터 설정
         setFormData({
@@ -149,7 +148,9 @@ export default function ReferenceEditPage() {
       }
 
       // 파일 데이터 준비
-      const filesFormData = referenceService.prepareFilesFormData(formData.files);
+      const filesFormData = referenceService.prepareFilesFormData(
+        formData.files
+      );
 
       // API 호출
       await referenceService.updateReference(referenceId, {
@@ -157,7 +158,7 @@ export default function ReferenceEditPage() {
         title: formData.title,
         keywords: formData.keywords,
         memo: formData.memo,
-        files: filesFormData
+        files: filesFormData,
       });
 
       showToast("레퍼런스가 수정되었습니다.", "success");
@@ -183,7 +184,9 @@ export default function ReferenceEditPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-2">
-            <h1 className="text-[#62BA9B] text-2xl font-semibold">레퍼런스 수정</h1>
+            <h1 className="text-[#62BA9B] text-2xl font-semibold">
+              레퍼런스 수정
+            </h1>
             <span className="text-sm text-gray-500">* 필수 항목</span>
           </div>
           <button

--- a/src/pages/reference/ReferenceListPage.tsx
+++ b/src/pages/reference/ReferenceListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useRecoilState } from "recoil";
 import { useNavigate } from "react-router-dom";
 import { FilePlus, LayoutGrid, Text } from "lucide-react";
 import Dropdown from "@/components/common/Dropdown";
@@ -20,7 +20,7 @@ import Alert from "@/components/common/Alert";
 import { Reference } from "@/types/reference";
 
 // ReferenceCard와 리스트에서 공통으로 사용할 타입 정의
-interface ReferenceListItem {
+export interface ReferenceListItem {
   _id: string;
   createAndShare?: boolean;
   collectionId: string;
@@ -45,7 +45,7 @@ export default function ReferenceListPage() {
   const sort = useRecoilValue(DropState);
   const modal = useRecoilValue(modalState);
   const alert = useRecoilValue(alertState);
-  const setCollections = useSetRecoilState(collectionState);
+  const [collections, setCollections] = useRecoilState(collectionState);
   const [isLoading, setIsLoading] = useState(true);
   const [referenceData, setReferenceData] = useState<ReferenceListItem[]>([]);
 
@@ -98,7 +98,6 @@ export default function ReferenceListPage() {
         // API 응답에서 데이터 변환
         const transformedData: ReferenceListItem[] = response.data.map(
           (reference) => {
-
             const files = reference.files || [];
             const previewURLs = files
               .filter((file) => file && file.type === "image")
@@ -109,6 +108,9 @@ export default function ReferenceListPage() {
               _id: reference._id,
               createAndShare: reference.createAndShare,
               collectionId: reference.collectionId,
+              collectionTitle: collections.data.find(
+                (item) => item._id === reference.collectionId
+              )?.title,
               title: reference.title,
               keywords: reference.keywords,
               previewURLs,
@@ -158,7 +160,7 @@ export default function ReferenceListPage() {
 
   return (
     <div className="min-h-screen font-sans">
-      {modal.isOpen && <Modal />}
+      {modal.isOpen && <Modal type={modal.type} />}
       {alert.isVisible && <Alert message={alert.massage} />}
       {referenceData?.length > 0 && <FloatingButton type="reference" />}
       <div className="flex flex-col max-w-7xl w-full px-4 sm:px-6 lg:px-8 mx-auto">

--- a/src/services/reference.ts
+++ b/src/services/reference.ts
@@ -8,14 +8,18 @@ import type {
   UpdateReferenceRequest,
   ReferenceResponse,
   ReferenceDetailResponse,
-  ReferenceListResponse
+  ReferenceListResponse,
 } from "@/types/reference";
 
 class ReferenceService {
   // 레퍼런스 목록 조회
-  async getReferenceList(params: GetReferenceParams): Promise<ReferenceListResponse> {
+  async getReferenceList(
+    params: GetReferenceParams
+  ): Promise<ReferenceListResponse> {
     try {
-      const response = await api.get<ReferenceListResponse>("/api/references", { params });
+      const response = await api.get<ReferenceListResponse>("/api/references", {
+        params,
+      });
       return response.data;
     } catch (error) {
       throw handleApiError(error);
@@ -25,18 +29,21 @@ class ReferenceService {
   // 단일 레퍼런스 조회
   async getReference(id: string): Promise<Reference> {
     try {
-      const response = await api.get<ReferenceDetailResponse>(`/api/references/${id}`);
+      const response = await api.get<ReferenceDetailResponse>(
+        `/api/references/${id}`
+      );
       const { referenceDetail } = response.data;
-      
+
       // API 응답을 Reference 타입으로 변환
       return {
         _id: id,
         collectionId: referenceDetail.collectionId,
         collectionTitle: referenceDetail.collectionTitle,
+        createdAt: referenceDetail.createdAt,
         title: referenceDetail.referenceTitle,
         keywords: referenceDetail.keywords || [],
-        memo: referenceDetail.memo || '',
-        files: referenceDetail.attachments.map(attachment => ({
+        memo: referenceDetail.memo || "",
+        files: referenceDetail.attachments.map((attachment) => ({
           _id: attachment.path,
           type: attachment.type,
           path: attachment.path,
@@ -44,10 +51,23 @@ class ReferenceService {
           images: attachment.images,
           previewURL: attachment.previewURL,
           previewURLs: attachment.previewURLs,
-        }))
+        })),
       };
     } catch (error) {
-      console.error('getReference API Error:', error);
+      console.error("getReference API Error:", error);
+      throw handleApiError(error);
+    }
+  }
+
+  // 레퍼런스 이동
+  async moveReference(ids: string[], title: string): Promise<void> {
+    try {
+      const response = await api.patch(`/api/references`, {
+        referenceIds: ids,
+        newCollection: title,
+      });
+      return response.data;
+    } catch (error) {
       throw handleApiError(error);
     }
   }

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -8,6 +8,10 @@ interface ModalState {
   title: string;
 }
 
+interface ShareModalState {
+  isOpen: boolean;
+}
+
 interface DropdownState {
   sortType: string;
   searchType: string;
@@ -27,6 +31,7 @@ interface AlertState {
   massage: string;
   ids: string[];
   isVisible: boolean;
+  title: string;
 }
 
 export const modalState = atom<ModalState>({
@@ -37,6 +42,11 @@ export const modalState = atom<ModalState>({
     id: "",
     title: "",
   },
+});
+
+export const shareModalState = atom<ShareModalState>({
+  key: "shareModalState",
+  default: { isOpen: false },
 });
 
 export const DropState = atom<DropdownState>({
@@ -59,7 +69,7 @@ export const floatingModeState = atom<FloatingState>({
   },
 });
 
-export const collectionState = atom<{ data: CollectionResponse['data'] }>({
+export const collectionState = atom<{ data: CollectionResponse["data"] }>({
   key: "collectionState",
   default: {
     data: [],
@@ -73,5 +83,6 @@ export const alertState = atom<AlertState>({
     massage: "",
     ids: [],
     isVisible: false,
+    title: "",
   },
 });

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -4,14 +4,14 @@
 export interface Reference {
   _id: string;
   collectionId: string;
-  collectionTitle?: string;  // 추가
+  collectionTitle?: string; // 추가
   title: string;
   keywords?: string[];
   memo?: string;
   files: ReferenceFile[];
   createAndShare?: boolean;
   previewURLs?: string[];
-  createdAt?: string;
+  createdAt: string;
 }
 
 // API 조회 파라미터
@@ -25,7 +25,7 @@ export interface GetReferenceParams {
 // 파일 관련 타입들
 export interface ReferenceFile {
   _id: string;
-  type: 'link' | 'image' | 'pdf' | 'file';
+  type: "link" | "image" | "pdf" | "file";
   path: string;
   size: number;
   images?: string[];
@@ -36,7 +36,7 @@ export interface ReferenceFile {
 // 레퍼런스 생성/수정 시 사용되는 파일 타입
 export interface CreateReferenceFile {
   id: string;
-  type: 'link' | 'image' | 'pdf' | 'file';
+  type: "link" | "image" | "pdf" | "file";
   content: string;
   name?: string;
 }
@@ -64,13 +64,14 @@ export interface CreateReferenceResponse {
 export interface ReferenceDetailResponse {
   message: string;
   referenceDetail: {
-    collectionId: string;     // 추가
+    collectionId: string; // 추가
     collectionTitle: string;
     referenceTitle: string;
+    createdAt: string;
     keywords: string[];
     memo: string;
     attachments: Array<{
-      type: 'link' | 'image' | 'pdf' | 'file';
+      type: "link" | "image" | "pdf" | "file";
       path: string;
       size: number;
       images?: string[];


### PR DESCRIPTION
# 컬렉션 상세 페이지 구현 및 api 연동

## 작업 내용
  - 레퍼런스 카드/리스트 생성날짜 출력 변경
  - 레퍼런스의 컬렉션 이동 모드 api 연동
  - 컬렉션 상세 페이지 구현
  - 공유 모달 UI 구현

## 스크린샷
|  **컬렉션 상세**   |  **이동 모드**   |
| :------------: | :------------: |
| ![image](https://github.com/user-attachments/assets/2f474061-10c2-4e4f-837b-c02e951ce3f3) | ![image](https://github.com/user-attachments/assets/56ce1e42-9ea6-4e06-a4fa-b5794919ddfc) |
| **공유 모달 UI** | ****  |
| ![image](https://github.com/user-attachments/assets/ca7e971e-9fe9-4788-8393-b15f8242e783)|  |