### PR TITLE
feat: 링크 프리뷰 기능 추가

### DIFF
--- a/src/components/reference/LinkPreview.tsx
+++ b/src/components/reference/LinkPreview.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import { Loader } from 'lucide-react';
+
+interface LinkPreviewProps {
+  url: string;
+}
+
+interface MetaData {
+  title?: string;
+  description?: string;
+  image?: string;
+  favicon?: string;
+}
+
+export default function LinkPreview({ url }: LinkPreviewProps) {
+  const [metadata, setMetadata] = useState<MetaData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const fetchMetadata = async () => {
+      try {
+        // CORS 이슈를 우회하기 위해 allorigins.win 프록시 서비스 사용
+        const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`;
+        const response = await fetch(proxyUrl);
+        const data = await response.json();
+        
+        if (data.contents) {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(data.contents, 'text/html');
+          
+          const meta: MetaData = {
+            title: doc.querySelector('meta[property="og:title"]')?.getAttribute('content') || 
+                  doc.querySelector('title')?.textContent || '',
+            description: doc.querySelector('meta[property="og:description"]')?.getAttribute('content') || 
+                        doc.querySelector('meta[name="description"]')?.getAttribute('content') || '',
+            image: doc.querySelector('meta[property="og:image"]')?.getAttribute('content') || '',
+            favicon: doc.querySelector('link[rel="icon"]')?.getAttribute('href') ||
+                    doc.querySelector('link[rel="shortcut icon"]')?.getAttribute('href') || 
+                    new URL('/favicon.ico', url).href
+          };
+          
+          setMetadata(meta);
+        }
+      } catch (err) {
+        console.error('Error fetching metadata:', err);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMetadata();
+  }, [url]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 bg-gray-50 rounded-lg">
+        <Loader className="w-6 h-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (error || !metadata) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 border border-gray-200 rounded-lg overflow-hidden hover:border-primary transition-colors">
+      <div className="flex p-4 gap-4">
+        {metadata.image && (
+          <div className="flex-shrink-0 w-24 h-24">
+            <img 
+              src={metadata.image} 
+              alt={metadata.title || 'Preview'} 
+              className="w-full h-full object-cover rounded"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <h4 className="text-base font-medium text-gray-900 truncate mb-1">
+            {metadata.title}
+          </h4>
+          {metadata.description && (
+            <p className="text-sm text-gray-500 line-clamp-2">
+              {metadata.description}
+            </p>
+          )}
+          <div className="flex items-center gap-2 mt-2">
+            {metadata.favicon && (
+              <img 
+                src={metadata.favicon} 
+                alt="favicon" 
+                className="w-4 h-4"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = 'none';
+                }}
+              />
+            )}
+            <span className="text-sm text-gray-400 truncate">
+              {new URL(url).hostname}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reference/LinkPreview.tsx
+++ b/src/components/reference/LinkPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Loader } from 'lucide-react';
 
 interface LinkPreviewProps {

--- a/src/pages/reference/ReferenceDetailPage.tsx
+++ b/src/pages/reference/ReferenceDetailPage.tsx
@@ -4,6 +4,7 @@ import { useToast } from "@/contexts/useToast";
 import { referenceService } from "@/services/reference";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import Alert from "@/components/common/Alert";
+import LinkPreview from "@/components/reference/LinkPreview";
 import { alertState } from "@/store/collection";
 import {
   Users,
@@ -78,6 +79,7 @@ export default function ReferenceDetailPage() {
 
   const renderFilePreview = (file: ReferenceFile) => {
     switch (file.type) {
+      // renderFilePreview 함수 내 link case 부분만 수정
       case "link":
         return (
           <div className="flex flex-col gap-2 bg-gray-50 rounded-lg p-4">
@@ -85,17 +87,20 @@ export default function ReferenceDetailPage() {
               <LinkIcon className="w-4 h-4" />
               <span>링크</span>
             </div>
-            <a
-              href={file.path}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-between group px-4 py-3 bg-white border border-gray-200 rounded-lg hover:border-primary transition-colors"
-            >
-              <span className="flex-1 truncate text-sm">{file.path}</span>
-              <span className="text-sm text-gray-500 group-hover:text-primary">
-                링크 이동
-              </span>
-            </a>
+            <div className="flex flex-col">
+              <a
+                href={file.path}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between group px-4 py-3 bg-white border border-gray-200 rounded-lg hover:border-primary transition-colors"
+              >
+                <span className="flex-1 truncate text-sm">{file.path}</span>
+                <span className="text-sm text-gray-500 group-hover:text-primary">
+                  링크 이동
+                </span>
+              </a>
+              <LinkPreview url={file.path} />
+            </div>
           </div>
         );
 


### PR DESCRIPTION
# feat: 링크 프리뷰 기능 추가

## 구현 내용
- 레퍼런스 상세 페이지에 링크 프리뷰 컴포넌트 추가
- allorigins.win 프록시를 통한 웹페이지 메타데이터 파싱
  - 제목, 설명, 이미지, 파비콘 정보 추출
  - Open Graph 태그 및 일반 메타태그 모두 지원
- 로딩 상태 및 에러 처리
- 반응형 디자인 적용

## 주의사항
- CORS 정책으로 인해 일부 웹사이트 미리보기 불가능
- allorigins.win 서비스 상태에 따른 기능 영향 가능성
- 필요시 대체 프록시 서비스 검토 필요

## 스크린샷
![image](https://github.com/user-attachments/assets/f949b705-7083-489b-af8d-a5b20893d23a)
![image](https://github.com/user-attachments/assets/66aecff7-22a5-4474-85fc-717b083e6440)
