### PR TITLE
feat: mage preview modal UI improvment

### DIFF
--- a/src/components/reference/ImagePreviewModal.tsx
+++ b/src/components/reference/ImagePreviewModal.tsx
@@ -17,6 +17,31 @@ export default function ImagePreviewModal({
   imageName,
   downloadUrl
 }: ImagePreviewModalProps) {
+  const handleDownload = async () => {
+    if (!downloadUrl) return;
+    
+    try {
+      // URL로부터 파일 다운로드
+      const response = await fetch(downloadUrl);
+      const blob = await response.blob();
+      
+      // 다운로드 링크 생성
+      const downloadLink = document.createElement('a');
+      downloadLink.href = window.URL.createObjectURL(blob);
+      downloadLink.download = imageName || 'image';  // 파일명 지정
+      
+      // 링크 클릭하여 다운로드 실행
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      
+      // 생성한 요소 정리
+      document.body.removeChild(downloadLink);
+      window.URL.revokeObjectURL(downloadLink.href);
+    } catch (error) {
+      console.error('Download failed:', error);
+    }
+  };
+
   return (
     <Modal
       isOpen={isOpen}
@@ -24,9 +49,8 @@ export default function ImagePreviewModal({
       className="max-w-4xl w-full mx-4 p-6"
     >
       <div className="space-y-4">
-        {/* 헤더 영역: 파일명과 다운로드 버튼 */}
-        <div className="flex items-center justify-between mb-2 pr-8"> {/* pr-8 추가하여 X 버튼과 간격 확보 */}
-          <div className="flex-1 min-w-0"> {/* min-w-0 추가하여 텍스트 오버플로우 방지 */}
+        <div className="flex items-center justify-between mb-2 pr-8">
+          <div className="flex-1 min-w-0">
             {imageName && (
               <h3 className="text-lg font-semibold text-gray-900 truncate">
                 {imageName}
@@ -35,7 +59,7 @@ export default function ImagePreviewModal({
           </div>
           {downloadUrl && (
             <button 
-              onClick={() => window.open(downloadUrl, '_blank')}
+              onClick={handleDownload}
               className="flex items-center gap-1.5 px-3 py-1.5 ml-4 text-sm bg-white border border-gray-200 rounded-md hover:border-primary hover:text-primary transition-colors"
             >
               <Download className="w-4 h-4" />
@@ -43,8 +67,6 @@ export default function ImagePreviewModal({
             </button>
           )}
         </div>
-        
-        {/* 이미지 영역 */}
         <div className="relative w-full" style={{ paddingTop: '75%' }}>
           <img
             src={imageUrl}

--- a/src/components/reference/ImagePreviewModal.tsx
+++ b/src/components/reference/ImagePreviewModal.tsx
@@ -1,18 +1,21 @@
 // src/components/reference/ImagePreviewModal.tsx
 import Modal from '@/components/common/Modal';
+import { Download } from 'lucide-react';
 
 interface ImagePreviewModalProps {
   isOpen: boolean;
   onClose: () => void;
   imageUrl: string;
   imageName?: string;
+  downloadUrl?: string;
 }
 
 export default function ImagePreviewModal({
   isOpen,
   onClose,
   imageUrl,
-  imageName
+  imageName,
+  downloadUrl
 }: ImagePreviewModalProps) {
   return (
     <Modal
@@ -21,9 +24,27 @@ export default function ImagePreviewModal({
       className="max-w-4xl w-full mx-4 p-6"
     >
       <div className="space-y-4">
-        {imageName && (
-          <h3 className="text-lg font-semibold text-gray-900">{imageName}</h3>
-        )}
+        {/* 헤더 영역: 파일명과 다운로드 버튼 */}
+        <div className="flex items-center justify-between mb-2 pr-8"> {/* pr-8 추가하여 X 버튼과 간격 확보 */}
+          <div className="flex-1 min-w-0"> {/* min-w-0 추가하여 텍스트 오버플로우 방지 */}
+            {imageName && (
+              <h3 className="text-lg font-semibold text-gray-900 truncate">
+                {imageName}
+              </h3>
+            )}
+          </div>
+          {downloadUrl && (
+            <button 
+              onClick={() => window.open(downloadUrl, '_blank')}
+              className="flex items-center gap-1.5 px-3 py-1.5 ml-4 text-sm bg-white border border-gray-200 rounded-md hover:border-primary hover:text-primary transition-colors"
+            >
+              <Download className="w-4 h-4" />
+              <span>다운로드</span>
+            </button>
+          )}
+        </div>
+        
+        {/* 이미지 영역 */}
         <div className="relative w-full" style={{ paddingTop: '75%' }}>
           <img
             src={imageUrl}

--- a/src/pages/reference/ReferenceDetailPage.tsx
+++ b/src/pages/reference/ReferenceDetailPage.tsx
@@ -29,6 +29,7 @@ export default function ReferenceDetailPage() {
   const [selectedImage, setSelectedImage] = useState<{
     url: string;
     name?: string;
+    downloadUrl?: string; // 추가: downloadUrl 타입 정의
   } | null>(null);
 
   useEffect(() => {
@@ -117,12 +118,16 @@ export default function ReferenceDetailPage() {
                   key={index}
                   className="relative aspect-video cursor-pointer group"
                   onClick={() =>
-                    setSelectedImage({ url, name: `이미지 ${index + 1}` })
+                    setSelectedImage({
+                      url,
+                      name: file.filenames?.[index] || `이미지 ${index + 1}`,
+                      downloadUrl: url, // 추가: downloadUrl 전달
+                    })
                   }
                 >
                   <img
                     src={url}
-                    alt={`Preview ${index + 1}`}
+                    alt={file.filenames?.[index] || `Preview ${index + 1}`}
                     className="w-full h-full object-cover rounded-lg"
                   />
                   <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity rounded-lg" />
@@ -287,6 +292,7 @@ export default function ReferenceDetailPage() {
         onClose={() => setSelectedImage(null)}
         imageUrl={selectedImage?.url || ""}
         imageName={selectedImage?.name}
+        downloadUrl={selectedImage?.downloadUrl} // 추가: downloadUrl 전달
       />
     </div>
   );

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -31,6 +31,7 @@ export interface ReferenceFile {
   images?: string[];
   previewURL?: string;
   previewURLs?: string[];
+  filenames?: string[]; // 추가
 }
 
 // 레퍼런스 생성/수정 시 사용되는 파일 타입


### PR DESCRIPTION
## 💡 PR 내용
이미지 프리뷰 모달 UI를 개선하고 다운로드 기능을 추가했습니다.

### 주요 변경사항
- 이미지 프리뷰 모달에 파일명 표시 추가
- 다운로드 버튼 추가 및 기능 구현
- 모달 헤더 레이아웃 개선 (X 버튼과 다운로드 버튼 간격 조정)
- ReferenceFile 타입에 filenames 필드 추가

### 스크린샷
![image](https://github.com/user-attachments/assets/88735ffd-5ffd-42ff-971e-7fa7eb6508c6)
![image](https://github.com/user-attachments/assets/28671d3c-7c2a-4785-8857-8510a5d7be41)


### 테스트 항목
- [ ] 이미지 프리뷰 모달에 파일명이 정상적으로 표시되는지 확인
- [ ] 다운로드 버튼 클릭 시 파일이 정상적으로 다운로드되는지 확인
- [ ] 모달 UI가 모든 화면 크기에서 정상적으로 표시되는지 확인