### PR TITLE
fix: reference type mismatch

### DIFF
--- a/src/pages/reference/ReferenceEditPage.tsx
+++ b/src/pages/reference/ReferenceEditPage.tsx
@@ -4,22 +4,19 @@ import React, { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useToast } from "@/contexts/useToast";
 import KeywordInput from "@/components/reference/KeywordInput";
-import FileUpload from "@/components/reference/FileUpload";
+import FileUpload, { FileItem } from "@/components/reference/FileUpload"; // FileItem 타입 import
 import { collectionService } from "@/services/collection";
 import { referenceService } from "@/services/reference";
+import type { UpdateReferenceRequest } from "@/types/reference";
 import { Loader } from "lucide-react";
 import type { CollectionCard } from "@/types/collection";
-import type {
-  CreateReferenceFile,
-  UpdateReferenceRequest,
-} from "@/types/reference";
 
 interface FormData {
   collection: string;
   title: string;
   keywords: string[];
   memo: string;
-  files: CreateReferenceFile[];
+  files: FileItem[];
 }
 
 export default function ReferenceEditPage() {
@@ -47,6 +44,7 @@ export default function ReferenceEditPage() {
   });
 
   // 레퍼런스 데이터 로딩
+
   useEffect(() => {
     const fetchData = async () => {
       if (!referenceId) {
@@ -60,22 +58,22 @@ export default function ReferenceEditPage() {
         const reference = await referenceService.getReference(referenceId);
 
         // 파일 데이터 변환
-        const convertedFiles: CreateReferenceFile[] = reference.files.map(
-          (file) => ({
-            id: file._id,
-            type: file.type,
-            content:
-              file.type === "link"
-                ? file.path
-                : file.previewURL || file.previewURLs?.[0] || "",
-            name: file.path.split("/").pop() || "",
-          })
-        );
+        const convertedFiles: FileItem[] = reference.files.map((file) => ({
+          id: file._id,
+          type: file.type,
+          content:
+            file.type === "link"
+              ? file.path
+              : file.previewURL || file.previewURLs?.[0] || "",
+          name:
+            file.type === "link"
+              ? undefined
+              : file.path.split("/").pop() || undefined,
+        }));
 
-        // 폼 데이터 설정
         setFormData({
           collection: reference.collectionTitle || "",
-          title: reference.title,
+          title: reference.title, // referenceTitle을 title로 수정
           keywords: reference.keywords || [],
           memo: reference.memo || "",
           files:
@@ -122,6 +120,10 @@ export default function ReferenceEditPage() {
 
     fetchCollections();
   }, [showToast]);
+
+  const handleFilesChange = (files: FileItem[]) => {
+    setFormData((prev) => ({ ...prev, files }));
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -318,7 +320,7 @@ export default function ReferenceEditPage() {
             <div className="border border-gray-300 rounded-lg p-4">
               <FileUpload
                 files={formData.files}
-                onChange={(files) => setFormData({ ...formData, files })}
+                onChange={handleFilesChange}
                 maxFiles={5}
                 disabled={isSubmitting}
               />

--- a/src/services/reference.ts
+++ b/src/services/reference.ts
@@ -2,272 +2,308 @@ import api from "@/utils/api";
 import { authUtils } from "@/store/auth";
 import { handleApiError } from "@/utils/errorHandler";
 import type {
- GetReferenceParams,
- Reference,
- CreateReferenceFile,
- CreateReferenceResponse,
- UpdateReferenceRequest,
- ReferenceResponse,
- ReferenceDetailResponse,
- ReferenceListResponse,
+  GetReferenceParams,
+  Reference,
+  CreateReferenceFile,
+  CreateReferenceResponse,
+  UpdateReferenceRequest,
+  ReferenceResponse,
+  ReferenceDetailResponse,
+  ReferenceListResponse,
+  UploadImageData,
 } from "@/types/reference";
 
 class ReferenceService {
- private baseUrl = "https://api.refhub.site";
+  private baseUrl = "https://api.refhub.site";
 
- private async fetchWithAuth(url: string): Promise<string> {
-   try {
-     const token = authUtils.getToken();
-     const response = await fetch(url, {
-       headers: {
-         Authorization: `Bearer ${token}`
-       }
-     });
-     const blob = await response.blob();
-     return URL.createObjectURL(blob);
-   } catch (error) {
-     console.error('Error fetching image:', error);
-     return url;
-   }
- }
+  private async fetchWithAuth(url: string): Promise<string> {
+    try {
+      const token = authUtils.getToken();
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const blob = await response.blob();
+      return URL.createObjectURL(blob);
+    } catch (error) {
+      console.error("Error fetching image:", error);
+      return url;
+    }
+  }
 
- private async transformUrl(url?: string): Promise<string> {
-   if (!url) return '';
-   
-   if (!url.includes('://')) {
-     const fullUrl = `${this.baseUrl}${url}`;
-     if (url.includes('/api/references/file/')) {
-       return await this.fetchWithAuth(fullUrl);
-     }
-     return fullUrl;
-   }
-   
-   if (url.includes('api.refhub.site')) {
-     if (url.includes('/api/references/file/')) {
-       return await this.fetchWithAuth(url);
-     }
-     return url;
-   }
-   
-   if (url.includes('refhub.my')) {
-     const newUrl = url.replace('refhub.my', 'api.refhub.site');
-     if (newUrl.includes('/api/references/file/')) {
-       return await this.fetchWithAuth(newUrl);
-     }
-     return newUrl;
-   }
-   
-   return url;
- }
+  private async transformUrl(url?: string): Promise<string> {
+    if (!url) return "";
 
- // 레퍼런스 목록 조회
- async getReferenceList(
-   params: GetReferenceParams
- ): Promise<ReferenceListResponse> {
-   try {
-     const response = await api.get<ReferenceListResponse>("/api/references", {
-       params,
-     });
-     return response.data;
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+    if (!url.includes("://")) {
+      const fullUrl = `${this.baseUrl}${url}`;
+      if (url.includes("/api/references/file/")) {
+        return await this.fetchWithAuth(fullUrl);
+      }
+      return fullUrl;
+    }
 
- // 단일 레퍼런스 조회
- async getReference(id: string): Promise<Reference> {
-   try {
-     const response = await api.get<ReferenceDetailResponse>(
-       `/api/references/${id}`
-     );
-     const { referenceDetail } = response.data;
+    if (url.includes("api.refhub.site")) {
+      if (url.includes("/api/references/file/")) {
+        return await this.fetchWithAuth(url);
+      }
+      return url;
+    }
 
-     return {
-       _id: id,
-       collectionId: referenceDetail.collectionId,
-       collectionTitle: referenceDetail.collectionTitle,
-       createdAt: referenceDetail.createdAt,
-       title: referenceDetail.referenceTitle,
-       keywords: referenceDetail.keywords || [],
-       memo: referenceDetail.memo || "",
-       files: await Promise.all(referenceDetail.attachments.map(async (attachment) => ({
-         _id: attachment.path,
-         type: attachment.type,
-         path: attachment.path,
-         size: attachment.size,
-         images: attachment.images,
-         previewURL: attachment.previewURL ? await this.transformUrl(attachment.previewURL) : undefined,
-         previewURLs: attachment.previewURLs 
-           ? await Promise.all(attachment.previewURLs.map(url => this.transformUrl(url)))
-           : undefined,
-       }))),
-     };
-   } catch (error) {
-     console.error("getReference API Error:", error);
-     throw handleApiError(error);
-   }
- }
+    if (url.includes("refhub.my")) {
+      const newUrl = url.replace("refhub.my", "api.refhub.site");
+      if (newUrl.includes("/api/references/file/")) {
+        return await this.fetchWithAuth(newUrl);
+      }
+      return newUrl;
+    }
 
- // 레퍼런스 이동
- async moveReference(ids: string[], title: string): Promise<void> {
-   try {
-     const response = await api.patch(`/api/references`, {
-       referenceIds: ids,
-       newCollection: title,
-     });
-     return response.data;
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+    return url;
+  }
 
- // 레퍼런스 생성
- async createReference({
-   collectionTitle,
-   title,
-   keywords,
-   memo,
-   files,
- }: UpdateReferenceRequest): Promise<CreateReferenceResponse> {
-   try {
-     const formData = new FormData();
-     formData.append("collectionTitle", collectionTitle);
-     formData.append("title", title);
+  // 레퍼런스 목록 조회
+  async getReferenceList(
+    params: GetReferenceParams
+  ): Promise<ReferenceListResponse> {
+    try {
+      const response = await api.get<ReferenceListResponse>("/api/references", {
+        params,
+      });
+      return response.data;
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-     if (keywords?.length) {
-       formData.append("keywords", keywords.join(" "));
-     }
+  // 단일 레퍼런스 조회
+  async getReference(id: string): Promise<Reference> {
+    try {
+      const response = await api.get<ReferenceDetailResponse>(
+        `/api/references/${id}`
+      );
+      const { referenceDetail } = response.data;
 
-     if (memo) {
-       formData.append("memo", memo);
-     }
+      return {
+        _id: id,
+        collectionId: referenceDetail.collectionId,
+        collectionTitle: referenceDetail.collectionTitle,
+        createdAt: referenceDetail.createdAt,
+        title: referenceDetail.referenceTitle,
+        keywords: referenceDetail.keywords || [],
+        memo: referenceDetail.memo || "",
+        files: await Promise.all(
+          referenceDetail.attachments.map(async (attachment) => ({
+            _id: attachment.path,
+            type: attachment.type,
+            path: attachment.path,
+            size: attachment.size,
+            images: attachment.images,
+            previewURL: attachment.previewURL
+              ? await this.transformUrl(attachment.previewURL)
+              : undefined,
+            previewURLs: attachment.previewURLs
+              ? await Promise.all(
+                  attachment.previewURLs.map((url) => this.transformUrl(url))
+                )
+              : undefined,
+          }))
+        ),
+      };
+    } catch (error) {
+      console.error("getReference API Error:", error);
+      throw handleApiError(error);
+    }
+  }
 
-     // Append files from the provided FormData
-     for (const [key, value] of files.entries()) {
-       formData.append(key, value);
-     }
+  // 레퍼런스 이동
+  async moveReference(ids: string[], title: string): Promise<void> {
+    try {
+      const response = await api.patch(`/api/references`, {
+        referenceIds: ids,
+        newCollection: title,
+      });
+      return response.data;
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-     const response = await api.post<CreateReferenceResponse>(
-       "/api/references/add",
-       formData,
-       {
-         headers: {
-           "Content-Type": "multipart/form-data",
-         },
-       }
-     );
+  // 레퍼런스 생성
+  async createReference({
+    collectionTitle,
+    title,
+    keywords,
+    memo,
+    files,
+  }: UpdateReferenceRequest): Promise<CreateReferenceResponse> {
+    try {
+      const formData = new FormData();
+      formData.append("collectionTitle", collectionTitle);
+      formData.append("title", title);
 
-     return response.data;
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+      if (keywords?.length) {
+        formData.append("keywords", keywords.join(" "));
+      }
 
- // 레퍼런스 수정
- async updateReference(
-   id: string,
-   { collectionTitle, title, keywords, memo, files }: UpdateReferenceRequest
- ): Promise<ReferenceResponse> {
-   try {
-     const formData = new FormData();
-     formData.append("collectionTitle", collectionTitle);
-     formData.append("title", title);
+      if (memo) {
+        formData.append("memo", memo);
+      }
 
-     if (keywords?.length) {
-       formData.append("keywords", keywords.join(" "));
-     }
+      // Append files from the provided FormData
+      for (const [key, value] of files.entries()) {
+        formData.append(key, value);
+      }
 
-     if (memo) {
-       formData.append("memo", memo);
-     }
+      const response = await api.post<CreateReferenceResponse>(
+        "/api/references/add",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      );
 
-     // Append files from the provided FormData
-     for (const [key, value] of files.entries()) {
-       formData.append(key, value);
-     }
+      return response.data;
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-     const response = await api.patch<ReferenceResponse>(
-       `/api/references/${id}`,
-       formData,
-       {
-         headers: {
-           "Content-Type": "multipart/form-data",
-         },
-       }
-     );
+  // 레퍼런스 수정
+  async updateReference(
+    id: string,
+    { collectionTitle, title, keywords, memo, files }: UpdateReferenceRequest
+  ): Promise<ReferenceResponse> {
+    try {
+      const formData = new FormData();
+      formData.append("collectionTitle", collectionTitle);
+      formData.append("title", title);
 
-     return response.data;
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+      if (keywords?.length) {
+        formData.append("keywords", keywords.join(" "));
+      }
 
- // 레퍼런스 삭제
- async deleteReference(id: string): Promise<void> {
-   try {
-     await api.delete(`/api/references/${id}`);
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+      if (memo) {
+        formData.append("memo", memo);
+      }
 
- // 레퍼런스 여러개 삭제
- async deleteReferences(ids: string[]): Promise<void> {
-   try {
-     await api.delete("/api/references", {
-       data: { referenceIds: ids },
-     });
-   } catch (error) {
-     throw handleApiError(error);
-   }
- }
+      // Append files from the provided FormData
+      for (const [key, value] of files.entries()) {
+        formData.append(key, value);
+      }
 
- // 파일 데이터 준비
- prepareFilesFormData(files: CreateReferenceFile[]): FormData {
-   const formData = new FormData();
-   let imageCount = 1;
+      const response = await api.patch<ReferenceResponse>(
+        `/api/references/${id}`,
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      );
 
-   files.forEach((file) => {
-     if (file.type === "link") {
-       formData.append("links", file.content);
-     } else if (file.type === "image") {
-       try {
-         const images = JSON.parse(file.content);
-         if (Array.isArray(images)) {
-           images.forEach((image: { url: string }) => {
-             const blobData = this.base64ToBlob(image.url);
-             formData.append(`images${imageCount}`, blobData);
-           });
-           imageCount++;
-         }
-       } catch (error) {
-         console.error("이미지 데이터 파싱 실패:", error);
-       }
-     } else if (file.type === "pdf") {
-       const blobData = this.base64ToBlob(file.content);
-       formData.append("files", blobData, file.name);
-     } else {
-       const blobData = this.base64ToBlob(file.content);
-       formData.append("otherFiles", blobData, file.name);
-     }
-   });
+      return response.data;
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-   return formData;
- }
+  // 레퍼런스 삭제
+  async deleteReference(id: string): Promise<void> {
+    try {
+      await api.delete(`/api/references/${id}`);
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
- private base64ToBlob(base64: string): Blob {
-   const parts = base64.split(";base64,");
-   const contentType = parts[0].split(":")[1] || "";
-   const raw = window.atob(parts[1]);
-   const rawLength = raw.length;
-   const uInt8Array = new Uint8Array(rawLength);
+  // 레퍼런스 여러개 삭제
+  async deleteReferences(ids: string[]): Promise<void> {
+    try {
+      await api.delete("/api/references", {
+        data: { referenceIds: ids },
+      });
+    } catch (error) {
+      throw handleApiError(error);
+    }
+  }
 
-   for (let i = 0; i < rawLength; ++i) {
-     uInt8Array[i] = raw.charCodeAt(i);
-   }
+  // 파일 데이터 준비
+  // ReferenceService의 prepareFilesFormData 메서드 수정
+  prepareFilesFormData(files: CreateReferenceFile[]): FormData {
+    const formData = new FormData();
+    let imageCount = 1;
 
-   return new Blob([uInt8Array], { type: contentType });
- }
+    files.forEach((file) => {
+      if (file.type === "link") {
+        formData.append("links", file.content as string);
+      } else if (file.type === "image") {
+        try {
+          const images = JSON.parse(
+            file.content as string
+          ) as UploadImageData[];
+          if (Array.isArray(images)) {
+            const imageBlobs = images.map((image) => {
+              if (
+                typeof image.url === "string" &&
+                image.url.startsWith("data:")
+              ) {
+                return {
+                  blob: this.base64ToBlob(image.url),
+                  name: image.name,
+                };
+              }
+              return {
+                blob: image.url as Blob,
+                name: image.name,
+              };
+            });
+
+            imageBlobs.forEach((imageData, idx) => {
+              const fieldName = `images${imageCount}`;
+              formData.append(
+                fieldName,
+                imageData.blob,
+                imageData.name || `image${idx + 1}.jpg`
+              );
+            });
+            imageCount++;
+          }
+        } catch (error) {
+          console.error("이미지 데이터 파싱 실패:", error);
+        }
+      } else if (file.type === "pdf" || file.type === "file") {
+        if (
+          typeof file.content === "string" &&
+          file.content.startsWith("data:")
+        ) {
+          const blobData = this.base64ToBlob(file.content);
+          const fieldName = file.type === "pdf" ? "files" : "otherFiles";
+          formData.append(fieldName, blobData, file.name);
+        } else {
+          const fieldName = file.type === "pdf" ? "files" : "otherFiles";
+          formData.append(fieldName, file.content as Blob, file.name);
+        }
+      }
+    });
+
+    return formData;
+  }
+
+  private base64ToBlob(base64: string): Blob {
+    const parts = base64.split(";base64,");
+    const contentType = parts[0].split(":")[1] || "";
+    const raw = window.atob(parts[1]);
+    const rawLength = raw.length;
+    const uInt8Array = new Uint8Array(rawLength);
+
+    for (let i = 0; i < rawLength; ++i) {
+      uInt8Array[i] = raw.charCodeAt(i);
+    }
+
+    return new Blob([uInt8Array], { type: contentType });
+  }
 }
 
 export const referenceService = new ReferenceService();

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -35,13 +35,16 @@ export interface ReferenceFile {
 }
 
 // 레퍼런스 생성/수정 시 사용되는 파일 타입
+export interface UploadImageData {
+  url: string | Blob;
+  name?: string;
+}
 export interface CreateReferenceFile {
   id: string;
   type: "link" | "image" | "pdf" | "file";
-  content: string;
+  content: string | Blob;
   name?: string;
 }
-
 // 레퍼런스 생성/수정 요청 페이로드
 export interface UpdateReferenceRequest {
   collectionTitle: string;


### PR DESCRIPTION
## 파일 업로드 관련 타입 불일치 문제 해결

### 변경사항
- CreateReferenceFile과 FileItem 타입 간 호환성 문제 해결
- 파일 업로드 컴포넌트의 타입 정의 개선
- 파일 처리 로직 안정성 향상

### 주요 수정사항
1. `FileItem` 인터페이스의 `content` 필드 타입을 `string | Blob`으로 변경
2. 파일 업로드 처리 로직에서 Blob 객체 직접 사용하도록 수정
3. Reference 서비스 레이어의 타입 정의 적용

### 테스트 항목
- [ ] 이미지 파일 업로드 정상 동작 확인
- [ ] PDF 파일 업로드 정상 동작 확인
- [ ] 일반 파일 업로드 정상 동작 확인
- [ ] 링크 입력 정상 동작 확인