### PR TITLE
로그인 오류 메시지 개선 (QA #0013)

### DIFF
--- a/src/contexts/ToastProvider.tsx
+++ b/src/contexts/ToastProvider.tsx
@@ -1,39 +1,52 @@
 // src/contexts/ToastProvider.tsx
-import { useState, useCallback } from 'react';
-import { Toast } from '@/components/common/Toast';
-import { ToastContext } from './ToastContext';
-import type { ToastType } from './types';
+import { useState, useCallback } from "react";
+import { Toast } from "@/components/common/Toast";
+import { ToastContext } from "./ToastContext";
+import type { ToastType } from "./types";
 
 interface ToastProviderProps {
   children: React.ReactNode;
 }
 
 export function ToastProvider({ children }: ToastProviderProps) {
-  const [toasts, setToasts] = useState<Array<{
-    id: string;
-    message: string;
-    type: ToastType;
-  }>>([]);
+  const [toasts, setToasts] = useState<
+    Array<{
+      id: string;
+      message: string;
+      type: ToastType;
+    }>
+  >([]);
 
-  const showToast = useCallback((message: string, type: ToastType = 'success') => {
-    const id = String(Date.now());
-    setToasts(prev => [...prev, { id, message, type }]);
+  const showToast = useCallback(
+    (message: string, type: ToastType = "success") => {
+      // 사용자에게 표시하기 적합하지 않은 기술적 오류 메시지 필터링
+      if (
+        message.includes("status code 400") ||
+        message.includes("Request failed")
+      ) {
+        message = "계정 정보가 올바르지 않습니다. 다시 시도해주세요.";
+      }
 
-    setTimeout(() => {
-      setToasts(prev => prev.filter(toast => toast.id !== id));
-    }, 3000);
-  }, []);
+      const id = String(Date.now());
+      setToasts((prev) => [...prev, { id, message, type }]);
+
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== id));
+      }, 3000);
+    },
+    []
+  );
 
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      {toasts.map(toast => (
+      {toasts.map((toast) => (
         <Toast
           key={toast.id}
           message={toast.message}
           type={toast.type}
           onClose={() => {
-            setToasts(prev => prev.filter(t => t.id !== toast.id));
+            setToasts((prev) => prev.filter((t) => t.id !== toast.id));
           }}
         />
       ))}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -15,6 +15,7 @@ export default function LoginPage() {
   const [rememberMe, setRememberMe] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const setShareModal = useSetRecoilState(shareModalState);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   const {
     register,
@@ -37,7 +38,10 @@ export default function LoginPage() {
     async (data: LoginForm) => {
       if (isLoading) return;
 
+      // 폼 제출 시 이전 오류 메시지 초기화
+      setLoginError(null);
       setIsLoading(true);
+
       try {
         await authService.login(data, rememberMe);
         setShareModal((prev) => ({ ...prev, userEmail: data.email }));
@@ -45,15 +49,21 @@ export default function LoginPage() {
         showToast("로그인이 완료되었습니다.", "success");
       } catch (error) {
         if (error instanceof Error) {
+          // 에러 메시지 토스트 표시
           showToast(error.message, "error");
+          // 동일한 에러 메시지를 폼 아래에도 표시하기 위해 상태 업데이트
+          setLoginError(error.message);
         } else {
-          showToast("로그인에 실패했습니다.", "error");
+          const defaultMsg =
+            "계정 정보가 올바르지 않습니다. 다시 시도해주세요.";
+          showToast(defaultMsg, "error");
+          setLoginError(defaultMsg);
         }
       } finally {
         setIsLoading(false);
       }
     },
-    [navigate, rememberMe, showToast, isLoading]
+    [navigate, rememberMe, showToast, isLoading, setShareModal]
   );
 
   return (
@@ -133,20 +143,28 @@ export default function LoginPage() {
               </Link>
             </div>
 
+            {/* 로그인 버튼 아래에 오류 메시지 표시 */}
             <button
               type="submit"
               disabled={!isButtonActive || isLoading}
               className={`
-                w-full h-14 rounded-lg font-medium transition-colors duration-200
-                ${
-                  isButtonActive && !isLoading
-                    ? "bg-primary hover:bg-primary-dark text-white"
-                    : "bg-[#8A8D8A] text-white cursor-not-allowed"
-                }
-              `}
+    w-full h-14 rounded-lg font-medium transition-colors duration-200
+    ${
+      isButtonActive && !isLoading
+        ? "bg-primary hover:bg-primary-dark text-white"
+        : "bg-[#8A8D8A] text-white cursor-not-allowed"
+    }
+  `}
             >
               {isLoading ? "로그인 중..." : "로그인"}
             </button>
+
+            {/* 오류 메시지 표시 영역 */}
+            {loginError && (
+              <div className="mt-2 text-red-500 text-sm text-center">
+                {loginError}
+              </div>
+            )}
           </form>
 
           <div className="text-center mt-6">

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -7,6 +7,7 @@ import type {
   VerifyCodeForm,
 } from "@/types/auth";
 import api from "@/utils/api";
+import axios, { AxiosError } from "axios";
 import { handleApiError } from "@/utils/errorHandler";
 import { authUtils } from "@/store/auth";
 
@@ -74,7 +75,35 @@ class AuthService {
       }
 
       return response.data;
-    } catch (error) {
+    } catch (err) {
+      // 명시적 타입 체크를 통해 error 객체 다루기
+      const error = err as Error | AxiosError;
+
+      // 특정 오류 타입에 대한 세밀한 처리 추가
+      if (axios.isAxiosError(error) && error.response) {
+        // HTTP 상태 코드에 따른 처리
+        if (error.response.status === 400) {
+          // 서버에서 오는 메시지가 있으면 사용
+          if (error.response.data && typeof error.response.data === "string") {
+            throw new Error(error.response.data);
+          } else if (
+            error.response.data &&
+            typeof error.response.data === "object" &&
+            "error" in error.response.data
+          ) {
+            throw new Error(error.response.data.error as string);
+          } else {
+            // 기본 400 오류 메시지
+            throw new Error(
+              "계정 정보가 올바르지 않습니다. 다시 시도해주세요."
+            );
+          }
+        } else if (error.response.status === 404) {
+          throw new Error("등록되지 않은 계정입니다. 회원가입을 진행해주세요.");
+        }
+      }
+
+      // 그 외 오류는 일반 오류 처리 함수로 위임
       throw handleApiError(error);
     }
   }

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -48,6 +48,9 @@ export const handleApiError = (error: unknown): never => {
       } else {
         // 상태 코드별 기본 에러 메시지
         switch (status) {
+          case 400:
+            message = "계정 정보가 올바르지 않습니다. 다시 시도해주세요.";
+            break;
           case 401:
             message = ERROR_MESSAGES.UNAUTHORIZED;
             break;


### PR DESCRIPTION
## 개요
- 로그인 실패 시 사용자 친화적인 오류 메시지 표시 개선
- 해결한 QA 이슈: #0013 (계정 정보 체크 에러처리 오류)

## 변경사항
- 로그인 API 오류 메시지 처리 로직 개선
- 400 에러 발생 시 사용자 친화적인 메시지 표시
- 영문, 숫자, 특수문자 조합 오류 시 명확한 안내 제공
- 오류 메시지를 토스트와 폼 하단에 모두 표시하여 가시성 개선

## 스크린샷
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/0d6effc2-df5f-405a-965a-c8885246e867" />

## 테스트 방법
1. 로그인 페이지 접속
2. 유효한 이메일과 잘못된 비밀번호(영문+숫자만 포함) 입력
3. 로그인 버튼 클릭
4. "계정 정보가 올바르지 않습니다. 다시 시도해주세요." 메시지 확인

## 관련 이슈
- https://www.notion.so/QA-0013-1b3fa429e6f780f886d1faff281f4885?pvs=4