### PR TITLE
fix: 중복 계정 가입 시 인증번호 전송 방지 및 오류 메시지 출력

### DIFF
--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -84,7 +84,11 @@ export default function SignupPage() {
       showToast("인증번호가 발송되었습니다.", "success");
     } catch (error) {
       if (error instanceof Error) {
-        showToast(error.message, "error");
+        if (error.message === "이미 가입된 계정입니다.") {
+          showToast(error.message, "error");
+        } else {
+          showToast("인증번호 전송에 실패했습니다.", "error");
+        }
       } else {
         showToast("인증번호 전송에 실패했습니다.", "error");
       }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -18,6 +18,10 @@ class AuthService {
       const response = await api.post("/api/users/email", { name, email });
       return response.data;
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        // 이미 존재하는 계정일 경우 에러 메시지 던지기
+        throw new Error("이미 가입된 계정입니다.");
+      }
       throw handleApiError(error);
     }
   }


### PR DESCRIPTION
## 버그 수정: 중복 계정 회원가입 오류 (#0027)

### 🛠️ 해결 방법
- 인증번호 전송 요청 시 서버에서 기존 계정을 확인하도록 변경. -> 백엔드 로직 수정
- `400` 응답을 받을 경우 "이미 가입된 계정입니다." 오류 메시지를 사용자에게 표시.

