### PR TITLE
fix: 드롭메뉴 오류 및 레퍼런스 영역 초과 시 키워드 개수 노출 처리

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -43,6 +43,12 @@ const Dropdown: React.FC<DropdownProps> = ({ type }) => {
   const [selectedOption, setSelectedOption] = useState(options[type][0].ko);
 
   useEffect(() => {
+    if (type === "array") {
+      setSelectedOption(
+        options["array"].find((el) => el.en === sort.sortType)?.ko || "최신순"
+      );
+    }
+
     const handleClickOutside = (event: MouseEvent) => {
       if (
         dropdownRef.current &&


### PR DESCRIPTION
## 변경 사항
- 정렬 드롭메뉴 텍스트 변경되도록 수정
- 레퍼런스 카드형 및 리스트형 키워드 영역 초과 시 초과된 키워드 개수가 노출되도록 처리

## 관련 이슈
- [QA #0093, #0138, #0240]: 정렬 드롭메뉴 텍스트 미변경 오류
- [QA #0146, #0157, #0247, #0258]: 레퍼런스 키워드 영역 초과 시 초과된 키워드 모두 노출
