### PR TITLE
fix: 사용자 권한에 따른 레퍼런스 더보기 및 체크박스 노출 여부 처리

### DIFF
--- a/src/components/reference/ReferenceCard.tsx
+++ b/src/components/reference/ReferenceCard.tsx
@@ -22,7 +22,10 @@ const ReferenceCard: React.FC<
   Pick<
     Reference,
     | "_id"
-    | "createAndShare"
+    | "shared"
+    | "creator"
+    | "editor"
+    | "viewer"
     | "title"
     | "keywords"
     | "previewData"
@@ -31,7 +34,8 @@ const ReferenceCard: React.FC<
   >
 > = ({
   _id,
-  createAndShare,
+  shared,
+  viewer,
   title,
   keywords = [],
   previewData = [],
@@ -126,7 +130,7 @@ const ReferenceCard: React.FC<
     setIsChecked(e.target.checked);
     setModeValue((prev: FloatingState) => ({
       ...prev,
-      isShared: [...prev.isShared, createAndShare ?? false],
+      isShared: [...prev.isShared, shared ?? false],
       checkItems: prev.checkItems.includes(e.target.id)
         ? prev.checkItems.filter((i) => i !== e.target.id)
         : [...prev.checkItems, e.target.id],
@@ -134,7 +138,7 @@ const ReferenceCard: React.FC<
   };
 
   const handleDelete = () => {
-    const text = createAndShare
+    const text = shared
       ? `${
           collectionTitle || "선택한"
         } 컬렉션의 ${title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.\n\n * 해당 컬렉션은 다른 사용자와 공유중입니다 *`
@@ -178,57 +182,58 @@ const ReferenceCard: React.FC<
 
   return (
     <div className="relative border border-gray-200 rounded-lg bg-white px-5">
-      {modeValue.isMove || modeValue.isDelete ? (
-        <div>
-          <input
-            type="checkbox"
-            id={_id}
-            checked={isChecked}
-            onChange={handleChange}
-            className="hidden"
-          />
-          <label
-            htmlFor={_id}
-            className={`w-5 h-5 absolute top-4 right-3 border-2 border-primary text-white flex items-center justify-center rounded cursor-pointer ${
-              isChecked ? "bg-primary" : "bg-white"
-            }`}
-          >
-            {isChecked && "✔"}
-          </label>
-        </div>
-      ) : (
-        <div ref={addRef}>
-          <EllipsisVertical
-            className="w-6 h-6 absolute top-4 right-1.5 hover:cursor-pointer hover:text-gray-600 transition-colors"
-            onClick={() => setIsOpen(!isOpen)}
-          />
-          {isOpen && (
-            <ul className="absolute top-12 right-1.5 gap-2 inline-flex flex-col bg-white border border-gray-200 rounded-lg shadow-lg min-w-[120px] z-10">
-              <li>
-                <button
-                  onClick={handleEdit}
-                  className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                >
-                  <PencilLine className="w-4 h-4 stroke-primary" />
-                  <span>수정</span>
-                </button>
-              </li>
-              <li>
-                <button
-                  onClick={handleDelete}
-                  className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                >
-                  <Trash2 className="w-4 h-4 stroke-[#f65063]" />
-                  <span>삭제</span>
-                </button>
-              </li>
-            </ul>
-          )}
-        </div>
-      )}
+      {!viewer &&
+        (modeValue.isMove || modeValue.isDelete ? (
+          <div>
+            <input
+              type="checkbox"
+              id={_id}
+              checked={isChecked}
+              onChange={handleChange}
+              className="hidden"
+            />
+            <label
+              htmlFor={_id}
+              className={`w-5 h-5 absolute top-4 right-3 border-2 border-primary text-white flex items-center justify-center rounded cursor-pointer ${
+                isChecked ? "bg-primary" : "bg-white"
+              }`}
+            >
+              {isChecked && "✔"}
+            </label>
+          </div>
+        ) : (
+          <div ref={addRef}>
+            <EllipsisVertical
+              className="w-6 h-6 absolute top-4 right-1.5 hover:cursor-pointer hover:text-gray-600 transition-colors"
+              onClick={() => setIsOpen(!isOpen)}
+            />
+            {isOpen && (
+              <ul className="absolute top-12 right-1.5 gap-2 inline-flex flex-col bg-white border border-gray-200 rounded-lg shadow-lg min-w-[120px] z-10">
+                <li>
+                  <button
+                    onClick={handleEdit}
+                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <PencilLine className="w-4 h-4 stroke-primary" />
+                    <span>수정</span>
+                  </button>
+                </li>
+                <li>
+                  <button
+                    onClick={handleDelete}
+                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <Trash2 className="w-4 h-4 stroke-[#f65063]" />
+                    <span>삭제</span>
+                  </button>
+                </li>
+              </ul>
+            )}
+          </div>
+        ))}
 
       <h2 className="flex flex-row gap-2 items-center text-base font-normal text-gray-500 mt-4 mb-1 mr-4">
-        {createAndShare && <Users className="w-5 h-5 stroke-gray-700" />}
+        {shared && <Users className="w-5 h-5 stroke-gray-700" />}
         <p className="flex-1 truncate">{collectionTitle || "불러오는 중..."}</p>
       </h2>
 

--- a/src/components/reference/ReferenceList.tsx
+++ b/src/components/reference/ReferenceList.tsx
@@ -159,7 +159,7 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
       (i) => i._id === item.collectionId
     )?.title;
 
-    const text = item.createAndShare
+    const text = item.shared
       ? `${collectionTitle} 컬렉션의 다른 사용자와 공유 중인 ${item.title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`
       : `${item.title}를 삭제하시겠습니까? \n삭제 후 복구할 수 없습니다.`;
 
@@ -226,13 +226,13 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
             >
               {(modeValue.isMove || modeValue.isDelete) && (
                 <td className="pl-3">
-                  <div>
+                  <div className={item.viewer ? "invisible" : ""}>
                     <input
                       type="checkbox"
                       id={item._id}
                       checked={isChecked[index]}
                       onChange={(e) =>
-                        handleChange(e, index, item.createAndShare || false)
+                        handleChange(e, index, item.shared || false)
                       }
                       className="hidden"
                     />
@@ -290,7 +290,11 @@ export default function ReferenceList({ items = [] }: DataTableProps) {
                 className="relative py-4"
                 ref={(el) => (menuRefs.current[item._id] = el)}
               >
-                <div className="more-button flex justify-center">
+                <div
+                  className={`more-button flex justify-center ${
+                    item.viewer ? "invisible" : ""
+                  }`}
+                >
                   <button
                     onClick={(e) => {
                       e.stopPropagation();

--- a/src/pages/collection/CollectionDetailPage.tsx
+++ b/src/pages/collection/CollectionDetailPage.tsx
@@ -84,7 +84,10 @@ export default function CollectionDetailPage() {
 
             return {
               _id: reference._id,
-              createAndShare: reference.createAndShare,
+              shared: reference.shared,
+              creator: reference.creator,
+              editor: reference.editor,
+              viewer: reference.viewer,
               collectionId: reference.collectionId,
               collectionTitle: collectionResponse.data.find(
                 (item) => item._id === reference.collectionId

--- a/src/pages/reference/ReferenceDetailPage.tsx
+++ b/src/pages/reference/ReferenceDetailPage.tsx
@@ -59,7 +59,7 @@ export default function ReferenceDetailPage() {
   const handleDelete = () => {
     if (!reference) return;
 
-    const text = reference.createAndShare
+    const text = reference.shared
       ? `${
           reference.collectionTitle || "선택한"
         } 컬렉션의 다른 사용자와 공유 중인 ${
@@ -210,7 +210,7 @@ export default function ReferenceDetailPage() {
         <div className="flex items-center justify-between mb-4">
           <div className="flex-1">
             <h2 className="flex items-center gap-2 text-base text-gray-500 mb-2">
-              {reference.createAndShare && (
+              {reference.shared && (
                 <Users className="w-5 h-5 stroke-gray-700" />
               )}
               <span>{reference.collectionTitle || "불러오는 중..."}</span>

--- a/src/pages/reference/ReferenceListPage.tsx
+++ b/src/pages/reference/ReferenceListPage.tsx
@@ -23,7 +23,10 @@ import { CollectionResponse } from "@/types/collection";
 // ReferenceCard와 리스트에서 공통으로 사용할 타입 정의
 export interface ReferenceListItem {
   _id: string;
-  createAndShare?: boolean;
+  shared?: boolean;
+  creator?: boolean;
+  editor?: boolean;
+  viewer?: boolean;
   collectionId: string;
   title: string;
   keywords?: string[];
@@ -137,7 +140,10 @@ export default function ReferenceListPage() {
 
             return {
               _id: reference._id,
-              createAndShare: reference.createAndShare,
+              shared: reference.shared,
+              creator: reference.creator,
+              editor: reference.editor,
+              viewer: reference.viewer,
               collectionId: reference.collectionId,
               collectionTitle: collections.data.find(
                 (item) => item._id === reference.collectionId

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -9,7 +9,10 @@ export interface Reference {
   keywords?: string[];
   memo?: string;
   files: ReferenceFile[];
-  createAndShare?: boolean;
+  shared?: boolean;
+  creator?: boolean;
+  editor?: boolean;
+  viewer?: boolean;
   previewData?: string[];
   createdAt: string;
 }


### PR DESCRIPTION
## 변경 사항
- viewer 권한인 사용자의 경우, 레퍼런스 더보기 버튼 비노출되도록 처리
- 이동 및 삭제 모드 경우, viewer 권한인 레퍼런스 체크박스 비노출되도록 처리

## 관련 이슈
- [QA #0149, #0152, #0250, #0253]: viewer 권한인 사용자의 경우에도 레퍼런스 더보기 버튼 노출
- [QA #0186, #0275, #0287]:  이동 및 삭제 모드 경우에도 viewer 권한인 레퍼런스 체크박스 노출