### PR TITLE
fix: 컬렉션 상세 페이지의 플로팅 버튼 노출 여부 반영 및 데이터 로딩 개선

### DIFF
--- a/src/components/common/FloatingButton.tsx
+++ b/src/components/common/FloatingButton.tsx
@@ -119,13 +119,26 @@ const FloatingButton: React.FC<FABProps> = ({ type, isData }) => {
     <div className="fixed bottom-[7%] right-[7%] flex flex-col items-center gap-8 z-10">
       {isOpen && (
         <div className="flex flex-col items-center gap-3">
+          {type != "collectionDetail" && (
+            <ActionButton
+              icon={
+                <FolderPlus
+                  className={`${iconStyles} stroke-primary bg-white`}
+                />
+              }
+              label="컬렉션"
+              time={1.2}
+              onClick={handleCreateCollection}
+            />
+          )}
+
           <ActionButton
             icon={
-              <FolderPlus className={`${iconStyles} stroke-primary bg-white`} />
+              <FilePlus className={`${iconStyles} stroke-primary bg-white`} />
             }
-            label="컬렉션"
-            time={1.2}
-            onClick={handleCreateCollection}
+            label="레퍼런스"
+            time={0.9}
+            onClick={() => navigate("/references/new")}
           />
           {type === "collectionDetail" && (
             <ActionButton
@@ -139,15 +152,7 @@ const FloatingButton: React.FC<FABProps> = ({ type, isData }) => {
               }
             />
           )}
-          <ActionButton
-            icon={
-              <FilePlus className={`${iconStyles} stroke-primary bg-white`} />
-            }
-            label="레퍼런스"
-            time={0.9}
-            onClick={() => navigate("/references/new")}
-          />
-          {type == "reference" && (
+          {type != "collection" && (
             <ActionButton
               icon={
                 <ArrowLeftRight

--- a/src/pages/collection/CollectionDetailPage.tsx
+++ b/src/pages/collection/CollectionDetailPage.tsx
@@ -172,7 +172,12 @@ export default function CollectionDetailPage() {
       {modal.isOpen && <Modal type={modal.type} />}
       {shareModal.isOpen && <ShareModal collectionId={collectionId || ""} />}
       {alert.isVisible && <Alert message={alert.massage} />}
-      {referenceData?.length > 0 && <FloatingButton type="collectionDetail" />}
+
+      <FloatingButton
+        type="collectionDetail"
+        isData={referenceData.length === 0 ? false : true}
+      />
+
       <div className="flex flex-col max-w-7xl w-full px-4 sm:px-6 lg:px-8 mx-auto">
         <div className="flex items-center justify-between mt-12 pb-6 border-b border-gray-400">
           <p className="flex items-center text-primary text-3xl font-bold gap-4">

--- a/src/pages/collection/CollectionPage.tsx
+++ b/src/pages/collection/CollectionPage.tsx
@@ -100,7 +100,12 @@ const CollectionPage: React.FC = () => {
         <ShareModal collectionId={shareModal.collectionId} />
       )}
       {alert.isVisible && <Alert message={alert.massage} />}
-      {collectionData?.data?.length > 0 && <FloatingButton type="collection" />}
+      {collectionData?.data?.length > 0 && (
+        <FloatingButton
+          type="collection"
+          isData={collectionData.data.length === 0 ? false : true}
+        />
+      )}
 
       <div className="flex flex-col max-w-7xl w-full px-4 sm:px-6 lg:px-8 mx-auto">
         <div className="flex items-center justify-between mt-10 mb-6">

--- a/src/pages/collection/CollectionPage.tsx
+++ b/src/pages/collection/CollectionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRecoilValue, useRecoilState } from "recoil";
 import {
   modalState,
@@ -30,56 +30,68 @@ const CollectionPage: React.FC = () => {
   const shareModal = useRecoilValue(shareModalState);
   const [collectionData, setCollectionData] =
     useRecoilState<CollectionResponse>(collectionState);
+  const alertPrevIsOpen = useRef<boolean>(alert.isVisible);
+  const modalPrevIsOpen = useRef<boolean>(modal.isOpen);
+  const sharePrevIsOpen = useRef<boolean>(shareModal.isOpen);
 
-  useEffect(() => {
-    const fetchCollections = async () => {
-      setIsLoading(true);
-      const params = {
-        page: currentPage,
-        sortBy: sort.sortType,
-        search: sort.searchWord,
-      };
-
-      try {
-        const response = await collectionService.getCollectionList(params);
-        setCollectionData(response);
-      } catch (error) {
-        if (error instanceof ApiError) {
-          showToast(error.message, "error");
-        } else if (error instanceof Error) {
-          showToast(error.message, "error");
-        } else {
-          showToast("컬렉션 가져오기를 실패했습니다.", "error");
-        }
-
-        // CollectionResponse 타입에 맞게 초기 상태 설정
-        setCollectionData({
-          currentPage: 1,
-          totalPages: 1,
-          totalItemCount: 0,
-          _id: "",
-          title: "",
-          isShared: false,
-          isFavorite: false,
-          refCount: 0,
-          previewImages: [],
-          data: [],
-        });
-      } finally {
-        setIsLoading(false);
-      }
+  const fetchCollections = async () => {
+    setIsLoading(true);
+    const params = {
+      page: currentPage,
+      sortBy: sort.sortType,
+      search: sort.searchWord,
     };
 
+    try {
+      const response = await collectionService.getCollectionList(params);
+      setCollectionData(response);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        showToast(error.message, "error");
+      } else if (error instanceof Error) {
+        showToast(error.message, "error");
+      } else {
+        showToast("컬렉션 가져오기를 실패했습니다.", "error");
+      }
+
+      // CollectionResponse 타입에 맞게 초기 상태 설정
+      setCollectionData({
+        currentPage: 1,
+        totalPages: 1,
+        totalItemCount: 0,
+        _id: "",
+        title: "",
+        isShared: false,
+        isFavorite: false,
+        refCount: 0,
+        previewImages: [],
+        data: [],
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
     fetchCollections();
-  }, [
-    sort,
-    modal.isOpen,
-    currentPage,
-    alert,
-    showToast,
-    setCollectionData,
-    shareModal.isOpen,
-  ]);
+  }, [sort, currentPage, showToast, setCollectionData]);
+
+  useEffect(() => {
+    if (alertPrevIsOpen.current === true && alert.isVisible === false) {
+      fetchCollections();
+    } else if (modalPrevIsOpen.current === true && modal.isOpen === false) {
+      fetchCollections();
+    } else if (
+      sharePrevIsOpen.current === true &&
+      shareModal.isOpen === false
+    ) {
+      fetchCollections();
+    }
+
+    alertPrevIsOpen.current = alert.isVisible;
+    modalPrevIsOpen.current = modal.isOpen;
+    sharePrevIsOpen.current = shareModal.isOpen;
+  }, [alert.isVisible, modal.isOpen, shareModal.isOpen]);
 
   const handleCreate = () => {
     setModal((prev) => ({ ...prev, isOpen: true, type: "create" }));


### PR DESCRIPTION
## 변경 사항
- 컬렉션 상세 페이지의 플로팅 내부 버튼 노출 여부 반영
- 컬렉션 페이지의 데이터 로딩 개선(알럿 및 모달창이 닫힐 때만 데이터 로딩되도록)

## 해결된 이슈
- QA #0160-0161: 플로팅 버튼 비노출